### PR TITLE
fixed code block bugs

### DIFF
--- a/client/js/components/editor-codeblock.js
+++ b/client/js/components/editor-codeblock.js
@@ -50,6 +50,7 @@ module.exports = (mde, mdeModalOpenState) => {
     },
     methods: {
       open: (ev) => {
+        mdeModalOpenState = true;
         $('#modal-editor-codeblock').addClass('is-active')
 
         _.delay(() => {

--- a/client/js/components/editor.js
+++ b/client/js/components/editor.js
@@ -150,8 +150,6 @@ module.exports = (alerts, pageEntryPath, socket) => {
           name: 'code-block',
           action: (editor) => {
             if (!mdeModalOpenState) {
-              // mdeModalOpenState = true
-
               if (mde.codemirror.doc.somethingSelected()) {
                 vueCodeBlock.initContent = mde.codemirror.doc.getSelection()
               }

--- a/client/js/components/editor.js
+++ b/client/js/components/editor.js
@@ -150,7 +150,7 @@ module.exports = (alerts, pageEntryPath, socket) => {
           name: 'code-block',
           action: (editor) => {
             if (!mdeModalOpenState) {
-              mdeModalOpenState = true
+              // mdeModalOpenState = true
 
               if (mde.codemirror.doc.somethingSelected()) {
                 vueCodeBlock.initContent = mde.codemirror.doc.getSelection()


### PR DESCRIPTION
Please enter the commit message for your changes. Lines starting

In the original code, the vueCodeblock doesn't work properly.
More specifically, it functions correctly at the first click. However, after click the "insert code block" or "discard", there is no possibility to call the vueCodeblock windows again expect for refreshing the whole page.

The problem is that mdeModalOpenState  is set to be true in editor.js. The value seems not to be changed in function cancel() in editor-codeblock.js (Sorry I am novice in js but I am guessing that the value instead of the reference is passed.)

My minor update actually copy the same idea from editor-image.js, moving the assignment of the mdeModalOpenState inside.
While, I am guessing that there are still two copy of mdeModalOpenState in these two scopes and may cause problem.

Thanks