### PR TITLE
Add viewSource theme config to toggle view source Button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ config.yml
 
 # IDE exclude
 .idea
+*.sublime-*

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -162,6 +162,7 @@ externalLogging:
 theme:
   primary: indigo
   alt: blue-grey
+  viewSource: "all"
   footer: blue-grey
   code:
     dark: true

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -162,7 +162,7 @@ externalLogging:
 theme:
   primary: indigo
   alt: blue-grey
-  viewSource: "all"
+  viewSource: all
   footer: blue-grey
   code:
     dark: true

--- a/server/app/data.yml
+++ b/server/app/data.yml
@@ -61,6 +61,7 @@ defaults:
       primary: indigo
       alt: blue-grey
       footer: blue-grey
+      viewSource: "none"
       code:
         dark: true
         colorize: true

--- a/server/app/data.yml
+++ b/server/app/data.yml
@@ -61,7 +61,7 @@ defaults:
       primary: indigo
       alt: blue-grey
       footer: blue-grey
-      viewSource: "none"
+      viewSource: false
       code:
         dark: true
         colorize: true

--- a/server/libs/config.js
+++ b/server/libs/config.js
@@ -28,6 +28,7 @@ module.exports = (confPaths) => {
         fs.readFileSync(confPaths.config, 'utf8')
       )
     )
+
     appdata = yaml.safeLoad(fs.readFileSync(confPaths.data, 'utf8'))
     appdata.regex = require(confPaths.dataRegex)
   } catch (ex) {

--- a/server/views/pages/view.pug
+++ b/server/views/pages/view.pug
@@ -15,9 +15,10 @@ block rootNavRight
       a.button.is-outlined(v-on:click='$store.dispatch("modalMovePage/open")')
         i.nc-icon-outline.arrows-1_shuffle-98
         span= t('nav.move')
-    a.button.is-outlined(href='/source/' + pageData.meta.path)
-      i.nc-icon-outline.education_paper
-      span= t('nav.source')
+    if appconfig.theme.viewSource == "all" || rights.write && appconfig.theme.viewSource == "write"
+      a.button.is-outlined(href='/source/' + pageData.meta.path)
+        i.nc-icon-outline.education_paper
+        span= t('nav.source')
     //-a.button.is-outlined(href='/hist/' + pageData.meta.path)
       i.nc-icon-outline.ui-2_time
       span= t('nav.history')

--- a/server/views/pages/view.pug
+++ b/server/views/pages/view.pug
@@ -15,7 +15,7 @@ block rootNavRight
       a.button.is-outlined(v-on:click='$store.dispatch("modalMovePage/open")')
         i.nc-icon-outline.arrows-1_shuffle-98
         span= t('nav.move')
-    if appconfig.theme.viewSource == "all" || rights.write && appconfig.theme.viewSource == "write"
+    if appconfig.theme.viewSource === "all" || rights.write && appconfig.theme.viewSource === "write"
       a.button.is-outlined(href='/source/' + pageData.meta.path)
         i.nc-icon-outline.education_paper
         span= t('nav.source')

--- a/server/views/pages/view.pug
+++ b/server/views/pages/view.pug
@@ -15,7 +15,7 @@ block rootNavRight
       a.button.is-outlined(v-on:click='$store.dispatch("modalMovePage/open")')
         i.nc-icon-outline.arrows-1_shuffle-98
         span= t('nav.move')
-    if appconfig.theme.viewSource === "all" || rights.write && appconfig.theme.viewSource === "write"
+    if appconfig.theme.viewSource === 'all' || (rights.write && appconfig.theme.viewSource === 'write')
       a.button.is-outlined(href='/source/' + pageData.meta.path)
         i.nc-icon-outline.education_paper
         span= t('nav.source')


### PR DESCRIPTION
# Add viewSource theme config to toggle view source Button

```yml
theme:
  ...
  viewSource: "all"            # "all" | "write" | "none"
```

- `All` will always show the view source button.
- `Write` will show the view source button for those with the ability to edit the page (write access)
- `none` will never show the view source button.

Additional notes:
- added sublime project to gitignore
- closes enhancement issue: #221 
- The docs should be updated to show this option.

