### PR TITLE
also check "cn" attribute for display name

### DIFF
--- a/server/models/user.js
+++ b/server/models/user.js
@@ -71,7 +71,7 @@ userSchema.statics.processProfile = (profile) => {
     email: primaryEmail,
     provider: profile.provider,
     providerId: profile.id,
-    name: profile.displayName || _.split(primaryEmail, '@')[0]
+    name: profile.displayName || profile.cn || _.split(primaryEmail, '@')[0]
   }, {
     new: true
   }).then((user) => {


### PR DESCRIPTION
LDAP queries to Open Directory on macOS Server don't include a "displayName" attribute, but the first name + surname combo is available in the "cn" attribute.

