### PR TITLE
Revise ja text.

### DIFF
--- a/server/locales/ja/browser.json
+++ b/server/locales/ja/browser.json
@@ -111,7 +111,7 @@
   "search": {
     "didyoumean": "もしかして...?",
     "nomatch": "一致する結果はありません",
-    "placeholder": "検査...",
-    "results": "検査結果"
+    "placeholder": "検索...",
+    "results": "検索結果"
   }
 }


### PR DESCRIPTION
It prefers to use "検索" to "検査" for "search".

