### PR TITLE
do not descend into .git directory when updating cache from agent

### DIFF
--- a/server/agent.js
+++ b/server/agent.js
@@ -114,7 +114,11 @@ global.db.onReady.then(() => {
           jobCbStreamDocsResolve = resolve
         })
 
-        klaw(repoPath).on('data', function (item) {
+        klaw(repoPath, {
+          filter: function(pathItem) {
+            return !pathItem.endsWith(".git");
+          }
+        }).on('data', function (item) {
           if (path.extname(item.path) === '.md' && path.basename(item.path) !== 'README.md') {
             let entryPath = entryHelper.parsePath(entryHelper.getEntryPathFromFullPath(item.path))
             let cachePath = entryHelper.getCachePath(entryPath)
@@ -151,6 +155,8 @@ global.db.onReady.then(() => {
               })
             )
           }
+        }).on("error", (err, item) => {
+          global.winston.error(err);
         }).on('end', () => {
           jobCbStreamDocsResolve(Promise.all(cacheJobs))
         })

--- a/server/agent.js
+++ b/server/agent.js
@@ -115,8 +115,8 @@ global.db.onReady.then(() => {
         })
 
         klaw(repoPath, {
-          filter: function(pathItem) {
-            return !pathItem.endsWith(".git");
+          filter: pathItem => {
+            return !pathItem.endsWith('.git')
           }
         }).on('data', function (item) {
           if (path.extname(item.path) === '.md' && path.basename(item.path) !== 'README.md') {
@@ -155,8 +155,8 @@ global.db.onReady.then(() => {
               })
             )
           }
-        }).on("error", (err, item) => {
-          global.winston.error(err);
+        }).on('error', (err, item) => {
+          global.winston.error(err)
         }).on('end', () => {
           jobCbStreamDocsResolve(Promise.all(cacheJobs))
         })


### PR DESCRIPTION
Fixes #297.

I filtered out not only `.git/index`, but the whole `.git` directory - I suppose you didn't intend to scan those for cache.