### PR TITLE
Use auth.defaultAccess, where default accounts can have write access

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -58,7 +58,7 @@ langRtl: false
 public: false
 
 auth:
-  defaultReadAccess: false
+  defaultAccess: false
   local:
     enabled: true
   google:

--- a/server/app/data.yml
+++ b/server/app/data.yml
@@ -18,7 +18,7 @@ defaults:
     langRtl: false
     public: false
     auth:
-      defaultReadAccess: false
+      defaultAccess: false
       local:
         enabled: true
       microsoft:

--- a/server/libs/config.js
+++ b/server/libs/config.js
@@ -36,6 +36,25 @@ module.exports = (confPaths) => {
     process.exit(1)
   }
 
+  // Update legacy options
+
+  if (appconfig.auth && appconfig.auth.defaultReadAccess !== undefined) {
+    if (appconfig.auth.defaultAccess === undefined) {
+      console.warn("auth.defaultReadAccess is deprecated, use `defaultAccess: read`")
+      appconfig.auth.defaultAccess = 'read'
+    } else if (appconfig.auth.defaultReadAccess === true) {
+      if (appconfig.auth.defaultAccess === 'write' || !appconfig.auth.defaultAccess) {
+        console.error(new Error('auth.defaultReadAccess conflicts with auth.defaultAccess'))
+        process.exit(1)
+      }
+    } else if (appconfig.auth.defaultReadAccess === false) {
+      if (appconfig.auth.defaultAccess !== false) {
+        console.error(new Error('auth.defaultReadAccess conflicts with auth.defaultAccess'))
+        process.exit(1)
+      }
+    }
+  }
+
   // Merge with defaults
 
   appconfig = _.defaultsDeep(appconfig, appdata.defaults.config)

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -76,7 +76,7 @@ userSchema.statics.processProfile = (profile) => {
     new: true
   }).then((user) => {
     // Handle unregistered accounts
-    if (!user && profile.provider !== 'local' && (appconfig.auth.defaultReadAccess || profile.provider === 'ldap' || profile.provider === 'azure')) {
+    if (!user && profile.provider !== 'local' && (appconfig.auth.defaultAccess || profile.provider === 'ldap' || profile.provider === 'azure')) {
       let nUsr = {
         email: primaryEmail,
         provider: profile.provider,
@@ -84,7 +84,7 @@ userSchema.statics.processProfile = (profile) => {
         password: '',
         name: profile.displayName || profile.name || profile.cn,
         rights: [{
-          role: 'read',
+          role: appconfig.auth.defaultAccess === 'write' ? 'write' : 'read',
           path: '/',
           exact: false,
           deny: false


### PR DESCRIPTION
This patch expands the functionality of `auth.defaultReadAccess` into a more-general `auth.defaultAccess` property that can be set to either `read` or `write`, allowing for users who join through trusted providers like Slack, LDAP, or Azure to interact with the wiki fully by setting `defaultAccess: write` in config.yml. (It also maintains legacy support for the previous `auth.defaultReadAccess` property.)