### PR TITLE
config.sample.yml: fix syntax for using ENV variables

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -3,6 +3,7 @@
 #######################################################################
 # Full explanation + examples in the documentation:
 # https://docs.requarks.io/wiki/install
+# You can use an ENV variable by using $(ENV_VAR_NAME) as the value
 
 # ---------------------------------------------------------------------
 # Title of this site
@@ -107,7 +108,6 @@ sessionSecret: 1234567890abcdefghijklmnopqrstuvxyz
 # ---------------------------------------------------------------------
 # Database Connection String
 # ---------------------------------------------------------------------
-# You can also use an ENV variable by using $ENV_VAR_NAME as the value
 
 db: mongodb://localhost:27017/wiki
 


### PR DESCRIPTION
The variable name must be enclosed in parentheses, otherwise it
is interpreted verbatim.

Move this tip to the top of the file, since it applies to all fields,
not just the 'db' field.

