### PR TITLE
Fix port checking

### DIFF
--- a/server/libs/config.js
+++ b/server/libs/config.js
@@ -42,7 +42,7 @@ module.exports = (confPaths) => {
 
   // Check port
 
-  if (appconfig.port < 1) {
+  if (!appconfig.port) {
     appconfig.port = process.env.PORT || 80
   }
 


### PR DESCRIPTION
I would not expect a negative, just a `null` - hopefully, even though it cannot be achieved without changing `app/data.yml` so it is never actually reached in most use cases and `process.env.PORT` cannot be used

I would advise removing default port from `app/data.yml` to fix that.