### PR TITLE
Strip out edit and create from start of path in rights

### DIFF
--- a/server/libs/rights.js
+++ b/server/libs/rights.js
@@ -56,7 +56,7 @@ module.exports = {
       manage: false
     }
     let rt = []
-    let p = _.chain(req.originalUrl).toLower().trim().value()
+    let p = _.chain(req.originalUrl).toLower().trim().replace(/^\/(edit|create)/, '').value()
 
     // Load user rights
 


### PR DESCRIPTION
Strips the edit and create url segments from the start of the path, which fixes the issue that requires you to add extra permission sets for `/create/...` and `/edit/...`

Fixes #147

