### PR TITLE
Propose to split out 2.1 milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Current and upcoming milestones *(major features only, see the [changelog](https
   - MongoDB is being phased out in favor of PostgreSQL + Redis. An upgrade tool will be provided to migrate existing data to the new system.
   - Node.js 8.9 LTS or later is now the minimum supported version.
 
-**2.0 Milestones**:
+**2.0 Milestone**:
 - [x] GraphQL API
 - [x] Migrate to PostgreSQL + Redis datastore
 - [x] Telemetry for analytics and crash reporting (Optional and fully anonymized)
@@ -99,21 +99,23 @@ Current and upcoming milestones *(major features only, see the [changelog](https
 - [x] Two-Factor Authentication (2FA)
 - [ ] New Navigation Concept :rocket:
 - [ ] Themes :rocket:
-- [ ] Modular editors, user-selectable: SimpleMDE (markdown), Monaco (code) or TinyMCE (wysiwyg)
 - [ ] Modular content parser :rocket:
-- [ ] Modular search engines: PostgreSQL search engine (default)
 - [ ] Multilingual versions of the same page (i18n)
 - [ ] History / Revert to previous version
 - [ ] Persist system settings to database instead of file-based
 - [ ] User Groups + Better permissions management
+
+:rocket: = Currently in development
+
+**2.1 Milestone**:
+- [ ] Modular editors, user-selectable: SimpleMDE (markdown), Monaco (code) or TinyMCE (wysiwyg)
+- [ ] Modular search engines: PostgreSQL search engine (default)
 - [ ] Tags per document / folder
 - [ ] Comments / Discussion per document
 - [ ] Profile page per user
 - [ ] Preview changes directly from the editor, without saving
 - [ ] Diagrams as code (Mermaid module)
 - [ ] Insert Link modal in Markdown Editor
-
-:rocket: = Currently in development
 
 **TBD Milestones**
 - [ ] Better simultaneous user editing handling


### PR DESCRIPTION
Currently there is a long queue of development items in the 2.0 milestone. Because master is unstable and under heavy changes, currently no one other than @NGPixel can contribute to open source development.

This is not to disparage @NGPixel's great work, but open source works best when an entire community can contribute. In this light I would like to suggest that we do all tickets which are expected to cause heavy changes first, then do "cosmetic" or "add-on" type features which can be implemented without major changes to the core in the 2.1 milestone while allowing 2.0 to stabilize. This will be hopefully allow the community to contribute some of the 2.1 patches so we all get what we want sooner.