### PR TITLE
turn off rgba on thumbnails to avoid being unable to upload files whi…

### DIFF
--- a/server/libs/uploads-agent.js
+++ b/server/libs/uploads-agent.js
@@ -235,6 +235,7 @@ module.exports = {
     return jimp.read(sourcePath).then(img => {
       return img
         .contain(150, 150)
+        .rgba(false)
         .write(destPath)
     })
   },


### PR DESCRIPTION
when you try to upload an image that when run through .contain() results in transparency being created, then converting the thumbnail, and thus the upload fails.

