### PR TITLE
Add autoRegisterIds for Slack unregistered accounts registration

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -80,6 +80,7 @@ auth:
     clientSecret: GITHUB_CLIENT_SECRET
   slack:
     enabled: false
+    allowDomains: []
     clientId: 'SLACK_CLIENT_ID'
     clientSecret: 'SLACK_CLIENT_SECRET'
   ldap:

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -80,7 +80,7 @@ auth:
     clientSecret: GITHUB_CLIENT_SECRET
   slack:
     enabled: false
-    allowDomains: []
+    autoRegisterIds: []
     clientId: 'SLACK_CLIENT_ID'
     clientSecret: 'SLACK_CLIENT_SECRET'
   ldap:

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -89,8 +89,8 @@ userSchema.statics.processProfile = (profile) => {
     new: true
   }).then((user) => {
     // Handle unregistered accounts
-    if (!user && profile.provider !== 'local' && (appconfig.auth.defaultReadAccess || profile.provider === 'ldap' || profile.provider === 'azure'
-                                                  || profile.provider === 'slack' && appconfig.auth.slack.autoRegisterIds.includes(profile.team.id)) ) {
+    if (!user && profile.provider !== 'local' && (appconfig.auth.defaultReadAccess || profile.provider === 'ldap' || profile.provider === 'azure' ||
+                                                  (profile.provider === 'slack' && appconfig.auth.slack.autoRegisterIds.includes(profile.team.id)))) {
       let nUsr = {
         email: primaryEmail,
         provider: profile.provider,

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -89,7 +89,8 @@ userSchema.statics.processProfile = (profile) => {
     new: true
   }).then((user) => {
     // Handle unregistered accounts
-    if (!user && profile.provider !== 'local' && (appconfig.auth.defaultReadAccess || profile.provider === 'ldap' || profile.provider === 'azure')) {
+    if (!user && profile.provider !== 'local' && (appconfig.auth.defaultReadAccess || profile.provider === 'ldap' || profile.provider === 'azure'
+                                                  || profile.provider === 'slack' && appconfig.auth.slack.autoRegisterIds.includes(profile.team.id)) ) {
       let nUsr = {
         email: primaryEmail,
         provider: profile.provider,


### PR DESCRIPTION
[first of all, huge compliments on the onboarding process and the wiki itself - it's a beautiful and intuitive experience :) ]

Please tell me what things I might need to fix! First time contributing, our team needed all slack users to be able to auto-register.

Thanks! :)

[one thing - I'm unsure about whether providerId is being set correctly in the case of Slack]

This may be similar to #302.