### PR TITLE
Added listen_address configuration option

### DIFF
--- a/server/app/data.yml
+++ b/server/app/data.yml
@@ -7,6 +7,7 @@ defaults:
   config:
     title: Wiki
     host: http://localhost
+    listenAddress: 0.0.0.0
     port: 80
     paths:
       repo: ./repo

--- a/server/index.js
+++ b/server/index.js
@@ -201,7 +201,7 @@ app.set('port', appconfig.port)
 var server = http.createServer(app)
 var io = socketio(server)
 
-server.listen(appconfig.port)
+server.listen(appconfig.port, appconfig.listenAddress)
 server.on('error', (error) => {
   if (error.syscall !== 'listen') {
     throw error


### PR DESCRIPTION
Hi there!
I had a need to restrict access to localhost, and couldn't find a way to do that in the documentation. This change allows setting listen_address in config.yml, the setting defaults to 0.0.0.0 (which binds all addresses, AFAIK).