### PR TITLE
feat: add allowed domain for google auth

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -66,6 +66,7 @@ auth:
     enabled: true
     clientId: GOOGLE_CLIENT_ID
     clientSecret: GOOGLE_CLIENT_SECRET
+    hd: 'example.com' # This is optional and can be removed
   microsoft:
     enabled: true
     clientId: MS_APP_ID

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -92,7 +92,7 @@ router.post('/login', bruteforce.prevent, function (req, res, next) {
  */
 
 router.get('/login/ms', passport.authenticate('windowslive', { scope: ['wl.signin', 'wl.basic', 'wl.emails'] }))
-router.get('/login/google', passport.authenticate('google', { scope: ['profile', 'email'] }))
+router.get('/login/google', passport.authenticate('google', { hd: appconfig.auth.google.hd, scope: ['profile', 'email'] }))
 router.get('/login/facebook', passport.authenticate('facebook', { scope: ['public_profile', 'email'] }))
 router.get('/login/github', passport.authenticate('github', { scope: ['user:email'] }))
 router.get('/login/slack', passport.authenticate('slack', { scope: ['identity.basic', 'identity.email'] }))

--- a/server/libs/auth.js
+++ b/server/libs/auth.js
@@ -61,6 +61,9 @@ module.exports = function (passport) {
         clientSecret: appconfig.auth.google.clientSecret,
         callbackURL: appconfig.host + '/login/google/callback'
       }, (accessToken, refreshToken, profile, cb) => {
+        if (appconfig.auth.google.hd && profile._json.domain !== appconfig.auth.google.hd) {
+          return cb(new Error('Wrong domain!'), null) || true
+        }
         db.User.processProfile(profile).then((user) => {
           return cb(null, user) || true
         }).catch((err) => {


### PR DESCRIPTION
Hi,

Google auth has support for including only verified domains. 
This minor change in the config and passport auth provider makes use of that support in two steps:
1. It appends the `hd=YOUR_DOMAIN` query parameter for auth redirect.
> The first part, although provides a good UI from Google to include the allowed domain on the sign in page, it is not entirely functional as Google will still allow a different email to pass.
2. Then comes part 2, in `server/libs/auth.js` we check the result of the auth callback and verify that the email is indeed from a valid domain. 

For this PR, I have only added support for just 1 allowed domains, although I have a feeling this may work for multiple domains as well and would love to test it out based on your feedback.