### PR TITLE
Lock MongoDB to v3

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   wikidb:
-    image: mongo
+    image: mongo:3
     expose:
       - '27017'
     command: '--smallfiles --bind_ip wikidb'


### PR DESCRIPTION
Because v4 is out and WikiJS doesn't seem to work with it

