### PR TITLE
Mongo: removed option "--bind_ip wikidb"

### DIFF
--- a/tools/docker-compose.yml
+++ b/tools/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: mongo
     expose:
       - '27017'
-    command: '--smallfiles'
+    command: '--smallfiles --bind_ip ::,0.0.0.0'
     environment:
       - 'MONGO_LOG_DIR=/dev/null'
     volumes:


### PR DESCRIPTION
Because inside container wikidb, the wikidb host doesn't resolve: since we can't link a host to its own container, the entry is not added to /etc/hosts by Docker the engine.

