### PR TITLE
Remove non-existing mdi-dependency

### DIFF
--- a/client/components/admin/admin-system.vue
+++ b/client/components/admin/admin-system.vue
@@ -105,17 +105,10 @@
 <script>
 import _ from 'lodash'
 
-import IconCube from 'mdi/cube'
-import IconDatabase from 'mdi/database'
-import IconNodeJs from 'mdi/nodejs'
-
 import systemInfoQuery from 'gql/admin/system/system-query-info.gql'
 
 export default {
   components: {
-    IconCube,
-    IconDatabase,
-    IconNodeJs
   },
   data() {
     return {


### PR DESCRIPTION
The npm package `mdi` does not exist under this name anymore, which leads to `yarn install` failing.

This is just a minor error, but it makes starting the dev build hard for people that want to look into the project and contribute.