### PR TITLE
ENH: passthrough to blob content in the repository

### DIFF
--- a/server/controllers/pages.js
+++ b/server/controllers/pages.js
@@ -221,10 +221,33 @@ router.post('/hist', (req, res, next) => {
   })
 })
 
+const validPathRe = new RegExp('^([a-z0-9/-' + appdata.regex.cjk + appdata.regex.arabic + ']+\\.[a-z0-9]+)$')
+
 /**
  * View document
  */
 router.get('/*', (req, res, next) => {
+
+  if (!res.locals.rights.write) {
+    return res.json({
+      ok: false,
+      error: lang.t('errors:forbidden')
+    })
+  }
+
+  let fileName = req.path
+  if (validPathRe.test(fileName)) {
+    res.sendFile(fileName, {
+      root: git.getRepoPath(),
+      dotfiles: 'deny'
+    }, (err) => {
+      if (err) {
+        res.status(err.status).end()
+      }
+    })
+    return true
+  }
+
   let safePath = entryHelper.parsePath(req.path)
 
   entries.fetch(safePath).then((pageData) => {


### PR DESCRIPTION
There may be relative links to other files on the wiki page. The most
common situation - images. It's much conveniently to store these images
near the md file and not in the upload directory (when you manually
commits to the repo). Wikijs should recognize such requests and
passthrough them, returning image. It shouln'd treat them as wiki-page query.

