### PR TITLE
Fix Contribute link

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,5 +137,5 @@ Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com
 
 <h2 align="center">Contributors</h2>
 
-This project exists thanks to all the people who contribute. [[Contribute]](https://github.com/Requarks/wiki/blob/master/CONTRIBUTING.md).
+This project exists thanks to all the people who contribute. [[Contribute]](https://github.com/Requarks/wiki/blob/master/.github/CONTRIBUTING.md).
 <a href="https://github.com/Requarks/wiki/graphs/contributors"><img src="https://opencollective.com/wikijs/contributors.svg?width=890" /></a>


### PR DESCRIPTION
The link to the CONTRIBUTING.md file was broken. It didn't have /.github/ in the path.

Old link: https://github.com/Requarks/wiki/blob/master/CONTRIBUTING.md
New link: https://github.com/Requarks/wiki/blob/master/.github/CONTRIBUTING.md