### PR TITLE
set default value to ''

### DIFF
--- a/server/db/migrations-sqlite/2.0.0-beta.127.js
+++ b/server/db/migrations-sqlite/2.0.0-beta.127.js
@@ -2,7 +2,7 @@ exports.up = knex => {
   return knex.schema
     .table('assets', table => {
       table.dropColumn('basename')
-      table.string('hash').notNullable()
+      table.string('hash').notNullable().defaultTo('')
     })
 }
 
@@ -10,6 +10,6 @@ exports.down = knex => {
   return knex.schema
     .table('assets', table => {
       table.dropColumn('hash')
-      table.string('basename').notNullable()
+      table.string('basename').notNullable().defaultTo('')
     })
 }


### PR DESCRIPTION
without this code:  `.defaultTo('')`

I got error:   Database Initialization Error: alter table `assets` add column `hash` varchar(255) not null - SQLITE_ERROR: Cannot add a NOT NULL column with default value NULL