### PR TITLE
Fix toolbar z-index issue with Safari

### DIFF
--- a/client/components/common/nav-header.vue
+++ b/client/components/common/nav-header.vue
@@ -317,7 +317,7 @@ export default {
 <style lang='scss'>
 
 .nav-header {
-  z-index: 1000;
+  z-index: 7;
 
   .v-toolbar__extension {
     padding: 0;


### PR DESCRIPTION
This should resolve #834 

I unfortunately can't test it, the project isn't building properly on my computer. I keep getting `Error: Cannot find module './DirectoryWatcher'` or `Error: Cannot find module 'bluebird'` when I run `make docker-dev-up`