### PR TITLE
fix: locale override not loading

### DIFF
--- a/server/core/localization.js
+++ b/server/core/localization.js
@@ -6,9 +6,6 @@ const Promise = require('bluebird')
 const fs = require('fs-extra')
 const path = require('path')
 const yaml = require('js-yaml')
-const { promisify } = require('util')
-
-const readFileAsync = promisify(fs.readFile)
 
 /* global WIKI */
 
@@ -81,7 +78,7 @@ module.exports = {
     // -> Load dev locale files if present
     if (WIKI.IS_DEBUG) {
       try {
-        const devEntriesRaw = await readFileAsync(path.join(WIKI.SERVERPATH, `locales/${locale}.yml`), 'utf8')
+        const devEntriesRaw = await fs.readFile(path.join(WIKI.SERVERPATH, `locales/${locale}.yml`), 'utf8')
         if (devEntriesRaw) {
           const devEntries = yaml.safeLoad(devEntriesRaw)
           _.forOwn(devEntries, (data, ns) => {
@@ -91,7 +88,7 @@ module.exports = {
           WIKI.logger.info(`Loaded dev locales from ${locale}.yml`)
         }
       } catch (err) {
-        throw new Error(err)
+        // ignore
       }
     }
   },

--- a/server/core/localization.js
+++ b/server/core/localization.js
@@ -6,6 +6,9 @@ const Promise = require('bluebird')
 const fs = require('fs-extra')
 const path = require('path')
 const yaml = require('js-yaml')
+const { promisify } = require('util')
+
+const readFileAsync = promisify(fs.readFile)
 
 /* global WIKI */
 
@@ -78,7 +81,7 @@ module.exports = {
     // -> Load dev locale files if present
     if (WIKI.IS_DEBUG) {
       try {
-        const devEntriesRaw = await fs.readFileAsync(path.join(WIKI.SERVERPATH, `locales/${locale}.yml`), 'utf8')
+        const devEntriesRaw = await readFileAsync(path.join(WIKI.SERVERPATH, `locales/${locale}.yml`), 'utf8')
         if (devEntriesRaw) {
           const devEntries = yaml.safeLoad(devEntriesRaw)
           _.forOwn(devEntries, (data, ns) => {
@@ -88,7 +91,7 @@ module.exports = {
           WIKI.logger.info(`Loaded dev locales from ${locale}.yml`)
         }
       } catch (err) {
-        // ignore
+        throw new Error(err)
       }
     }
   },


### PR DESCRIPTION
Locale override options were not working for me with the latest code due to fs.readFileAsync no longer existing in the latest node version. Error was silence too, so there was no feedback to the developer about the issue occurring. This patch should fix it though