### PR TITLE
save editor media asset path on reopen

### DIFF
--- a/client/components/editor/editor-modal-media.vue
+++ b/client/components/editor/editor-modal-media.vue
@@ -228,7 +228,7 @@
 
 <script>
 import _ from 'lodash'
-import { sync } from 'vuex-pathify'
+import { get, sync } from 'vuex-pathify'
 import vueFilePond from 'vue-filepond'
 import 'filepond/dist/filepond.min.css'
 
@@ -255,7 +255,6 @@ export default {
   data() {
     return {
       folders: [],
-      folderTree: [],
       files: [],
       assets: [],
       pagination: {},
@@ -268,9 +267,6 @@ export default {
         { text: 'Absolute Top Right', value: 'abstopright' }
       ],
       imageAlignment: '',
-      currentFolderId: 0,
-      currentFileId: null,
-      previousFolderId: 0,
       loading: false,
       newFolderDialog: false,
       newFolderName: '',
@@ -289,6 +285,9 @@ export default {
       set(val) { this.$emit('input', val) }
     },
     activeModal: sync('editor/activeModal'),
+    folderTree: get('editor/media@folderTree'),
+    currentFolderId: sync('editor/media@currentFolderId'),
+    currentFileId: sync('editor/media@currentFileId'),
     pageTotal () {
       if (this.pagination.rowsPerPage == null || this.pagination.totalItems == null) {
         return 0
@@ -400,12 +399,12 @@ export default {
       await this.$apollo.queries.assets.refetch()
     },
     downFolder(folder) {
-      this.folderTree.push(folder)
+      this.$store.commit('editor/pushMediaFolderTree', folder)
       this.currentFolderId = folder.id
       this.currentFileId = null
     },
     upFolder() {
-      this.folderTree.pop()
+      this.$store.commit('editor/popMediaFolderTree')
       const parentFolder = _.last(this.folderTree)
       this.currentFolderId = parentFolder ? parentFolder.id : 0
       this.currentFileId = null

--- a/client/store/editor.js
+++ b/client/store/editor.js
@@ -4,11 +4,24 @@ const state = {
   editor: '',
   content: '',
   mode: 'create',
-  activeModal: ''
+  activeModal: '',
+  media: {
+    folderTree: [],
+    currentFolderId: 0,
+    currentFileId: null
+  }
 }
 
 export default {
   namespaced: true,
   state,
-  mutations: make.mutations(state)
+  mutations: {
+    ...make.mutations(state),
+    pushMediaFolderTree: (state, folder) => {
+      state.media.folderTree = state.media.folderTree.concat(folder)
+    },
+    popMediaFolderTree: (state) => {
+      state.media.folderTree = state.media.folderTree.slice(0, -1)
+    }
+  }
 }


### PR DESCRIPTION
Before this, it was a hassle to insert multiple media assets nested deeply in folders, because on every reopen of the editor media modal, the path was reset.

1. Open media editor
2. Click through folder structure `a/b/c/d`
3. Insert image
4. Open media editor again - *path is reset*
5. Click through folder structure `a/b/c/d` *again*
6. Insert image
7. Rinse and repeat

Now, the modal saves the path, so:

1. Open media editor
2. Click through folder structure `a/b/c/d`
3. Insert image
4. Open media editor again ~~- *path is reset*~~
5. ~~Click through folder structure `a/b/c/d` *again*~~
6. Insert image
7. Rinse and repeat

It makes a huge difference when working with many assets and organizing them into folders nested more than one level deep.

---

Technically it simply moves the current folder structure to the store. I'm not sure if there is a better way with `vue-pathify` to change arrays, but I simply created manual mutations and called them the old vuexy way for now.