### PR TITLE
OpenShift-compatible Dockerfile

### DIFF
--- a/dev/openshift/Dockerfile
+++ b/dev/openshift/Dockerfile
@@ -1,0 +1,8 @@
+FROM requarks/wiki:beta
+
+USER root
+
+RUN chgrp -R 0 /wiki /logs && \
+    chmod -R g=u /wiki /logs
+
+USER 1001


### PR DESCRIPTION
This Dockerfile extends the `wiki:beta` image to update permissions on the application directories so the `root` group has identical permissions to the `node` user.  

Additional details can be found in OpenShift's documentation: https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html#openshift-specific-guidelines

This was tested on OpenShift v3.11.