### PR TITLE
Fixing typo on html-core renderer

### DIFF
--- a/server/modules/rendering/html-core/renderer.js
+++ b/server/modules/rendering/html-core/renderer.js
@@ -37,8 +37,8 @@ module.exports = {
       }
 
       // -> Strip host from local links
-      if (isHostSet && href.indexOf(WIKI.config.site.host) === 0) {
-        href = href.replace(WIKI.config.site.host, '')
+      if (isHostSet && href.indexOf(WIKI.config.host) === 0) {
+        href = href.replace(WIKI.config.host, '')
       }
 
       // -> Assign local / external tag


### PR DESCRIPTION
Fixing typo on: "server\modules\rendering\html-core\renderer.js"

Lines 40 and 41. Invalid reference to "WIKI.config.site.host" -- should be: "WIKI.config.host"

This was causing rendering issues when attempting to create some sample pages; such as: https://github.com/jbaez001/markdown-cheatsheet

Submitted #1020 for this. Possibly related to #847 as well.
