### PR TITLE
Plantuml markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "markdown-it-imsize": "2.0.1",
     "markdown-it-mark": "3.0.0",
     "markdown-it-mathjax": "2.0.0",
+    "markdown-it-plantuml": "1.4.1",
     "markdown-it-sub": "1.0.0",
     "markdown-it-sup": "1.0.0",
     "markdown-it-task-lists": "2.1.1",

--- a/server/modules/rendering/markdown-plantuml/definition.yml
+++ b/server/modules/rendering/markdown-plantuml/definition.yml
@@ -1,0 +1,35 @@
+key: markdownPlantuml
+title: PlantUML
+description: PlantUML Markdown Parser
+author: ethanmdavidson
+input: markdown
+output: html
+icon: mdi-factory
+enabledDefault: false
+dependsOn: markdownCore
+props:
+  openMarker:
+    type: String
+    default: @startuml
+    title: Open Marker
+    hint: String to use as opening delimiter
+  closeMarker:
+    type: String
+    default: @enduml
+    title: Close Marker
+    hint: String to use as closing delimiter
+  imageFormat:
+    type: String
+    default: svg
+    title: Image Format
+    hint: Format to use for rendered PlantUML images
+    enum:
+      - svg
+      - png
+      - latex
+      - ascii
+  server:
+    type: String
+    default: http://www.plantuml.com/plantuml
+    title: PlantUML Server
+    hint: PlantUML server used for image generation

--- a/server/modules/rendering/markdown-plantuml/definition.yml
+++ b/server/modules/rendering/markdown-plantuml/definition.yml
@@ -2,20 +2,18 @@ key: markdownPlantuml
 title: PlantUML
 description: PlantUML Markdown Parser
 author: ethanmdavidson
-input: markdown
-output: html
 icon: mdi-factory
-enabledDefault: false
+enabledDefault: true
 dependsOn: markdownCore
 props:
   openMarker:
     type: String
-    default: @startuml
+    default: "@startuml"
     title: Open Marker
     hint: String to use as opening delimiter
   closeMarker:
     type: String
-    default: @enduml
+    default: "@enduml"
     title: Close Marker
     hint: String to use as closing delimiter
   imageFormat:

--- a/server/modules/rendering/markdown-plantuml/definition.yml
+++ b/server/modules/rendering/markdown-plantuml/definition.yml
@@ -2,20 +2,28 @@ key: markdownPlantuml
 title: PlantUML
 description: PlantUML Markdown Parser
 author: ethanmdavidson
-icon: mdi-factory
+icon: mdi-sitemap
 enabledDefault: true
 dependsOn: markdownCore
 props:
+  server:
+    type: String
+    default: http://www.plantuml.com/plantuml
+    title: PlantUML Server
+    hint: PlantUML server used for image generation
+    order: 1
   openMarker:
     type: String
     default: "@startuml"
     title: Open Marker
     hint: String to use as opening delimiter
+    order: 2
   closeMarker:
     type: String
     default: "@enduml"
     title: Close Marker
     hint: String to use as closing delimiter
+    order: 3
   imageFormat:
     type: String
     default: svg
@@ -26,8 +34,4 @@ props:
       - png
       - latex
       - ascii
-  server:
-    type: String
-    default: http://www.plantuml.com/plantuml
-    title: PlantUML Server
-    hint: PlantUML server used for image generation
+    order: 4

--- a/server/modules/rendering/markdown-plantuml/renderer.js
+++ b/server/modules/rendering/markdown-plantuml/renderer.js
@@ -1,0 +1,16 @@
+const mdPlantUml = require('markdown-it-plantuml')()
+
+// ------------------------------------
+// Markdown - PlantUML Preprocessor
+// ------------------------------------
+
+module.exports = {
+  init (md, conf) {
+    md.use(mdPlantUml, {
+      openMarker: this.config.openMarker,
+      closeMarker: this.config.closeMarker,
+      imageFormat: this.config.imageFormat,
+      server: this.config.server
+    })
+  }
+}

--- a/server/modules/rendering/markdown-plantuml/renderer.js
+++ b/server/modules/rendering/markdown-plantuml/renderer.js
@@ -1,4 +1,4 @@
-const mdPlantUml = require('markdown-it-plantuml')()
+const mdPlantUml = require('markdown-it-plantuml')
 
 // ------------------------------------
 // Markdown - PlantUML Preprocessor
@@ -7,10 +7,10 @@ const mdPlantUml = require('markdown-it-plantuml')()
 module.exports = {
   init (md, conf) {
     md.use(mdPlantUml, {
-      openMarker: this.config.openMarker,
-      closeMarker: this.config.closeMarker,
-      imageFormat: this.config.imageFormat,
-      server: this.config.server
+      openMarker: conf.openMarker,
+      closeMarker: conf.closeMarker,
+      imageFormat: conf.imageFormat,
+      server: conf.server
     })
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8181,6 +8181,11 @@ markdown-it-mathjax@2.0.0:
   resolved "https://registry.yarnpkg.com/markdown-it-mathjax/-/markdown-it-mathjax-2.0.0.tgz#ae2b4f4c5c719a03f9e475c664f7b2685231d9e9"
   integrity sha1-ritPTFxxmgP55HXGZPeyaFIx2ek=
 
+markdown-it-plantuml@1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/markdown-it-plantuml/-/markdown-it-plantuml-1.4.1.tgz#3bd5e7d92eaa5c6c68eb29802f7b46a8e05ca998"
+  integrity sha512-13KgnZaGYTHBp4iUmGofzZSBz+Zj6cyqfR0SXUIc9wgWTto5Xhn7NjaXYxY0z7uBeTUMlc9LMQq5uP4OM5xCHg==
+
 markdown-it-sub@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/markdown-it-sub/-/markdown-it-sub-1.0.0.tgz#375fd6026eae7ddcb012497f6411195ea1e3afe8"


### PR DESCRIPTION
uses [markdown-it-plantuml](https://www.npmjs.com/package/markdown-it-plantuml).
Doesn't work in preview pane yet. Does the preview pane use a different rendering pipeline?