### PR TITLE
Fix Nav-Drawer shown on small screens

### DIFF
--- a/client/themes/default/components/page.vue
+++ b/client/themes/default/components/page.vue
@@ -304,6 +304,7 @@ export default {
   },
   data() {
     return {
+      breaktest: this.$vuetify.breakpoint.name, // just to see current breakpoint of vuetify
       navShown: false,
       navExpanded: false,
       upBtnShown: false,
@@ -371,7 +372,7 @@ export default {
   },
   mounted () {
     Prism.highlightAllUnder(this.$refs.container)
-    this.navShown = this.$vuetify.breakpoint.smAndUp
+    this.navShown = this.$vuetify.breakpoint.lgAndUp
 
     this.$nextTick(() => {
       if (window.location.hash && window.location.hash.length > 1) {


### PR DESCRIPTION
Only show Navigation Drawer  on  lg and  xl screens  on Page Load.

Fixes #1046 

Tested on Firefox Nightly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/requarks/wiki/1080)
<!-- Reviewable:end -->
