### PR TITLE
Fix remove page rules always remove the bottom rule

### DIFF
--- a/client/components/admin/admin-groups-edit-rules.vue
+++ b/client/components/admin/admin-groups-edit-rules.vue
@@ -243,8 +243,8 @@ export default {
         locales: []
       })
     },
-    removeRule(rule) {
-      this.group.pageRules.splice(_.findIndex(this.group.pageRules, ['id', rule.id]), 1)
+    removeRule(ruleId) {
+      this.group.pageRules.splice(_.findIndex(this.group.pageRules, ['id', ruleId]), 1)
     },
     comingSoon() {
       this.$store.commit('showNotification', {


### PR DESCRIPTION
Fix #997 .

Simply change the `removeRule` implementation on the client side should do the trick.