### PR TITLE
Fix go to headers for html-core renderer

### DIFF
--- a/server/jobs/render-page.js
+++ b/server/jobs/render-page.js
@@ -62,9 +62,10 @@ module.exports = async (pageId) => {
       const leafSlug = $('.toc-anchor', el).first().attr('href')
       $('.toc-anchor', el).remove()
 
+      const headerAnchor = $(el).attr('id') ? `#${$(el).attr('id')}` : undefined
       _.get(toc, leafPath).push({
         title: _.trim($(el).text()),
-        anchor: leafSlug,
+        anchor: leafSlug || headerAnchor,
         children: []
       })
     })

--- a/server/modules/rendering/html-core/renderer.js
+++ b/server/modules/rendering/html-core/renderer.js
@@ -142,6 +142,17 @@ module.exports = {
       }
     }
 
+    // --------------------------------
+    // Add id to headers for navigation
+    // --------------------------------
+
+    let headerIdCounter = 0
+    $('h1,h2,h3,h4,h5,h6').each((idx, el) => {
+      const headerId = _.split(_.toLower(_.trim($(el).text())), /\s+/).join('-') + '-' + headerIdCounter
+      headerIdCounter += 1
+      $(el).attr({ id: headerId })
+    })
+
     return $.html('body').replace('<body>', '').replace('</body>', '')
   }
 }

--- a/server/modules/rendering/html-core/renderer.js
+++ b/server/modules/rendering/html-core/renderer.js
@@ -148,6 +148,8 @@ module.exports = {
 
     let headerIdCounter = 0
     $('h1,h2,h3,h4,h5,h6').each((idx, el) => {
+      const elmId = $(el).attr('id')
+      if (elmId) return // Skip if this element already has id
       const headerId = _.split(_.toLower(_.trim($(el).text())), /\s+/).join('-') + '-' + headerIdCounter
       headerIdCounter += 1
       $(el).attr({ id: headerId })

--- a/server/modules/rendering/html-core/renderer.js
+++ b/server/modules/rendering/html-core/renderer.js
@@ -150,7 +150,20 @@ module.exports = {
     $('h1,h2,h3,h4,h5,h6').each((idx, el) => {
       const elmId = $(el).attr('id')
       if (elmId) return // Skip if this element already has id
-      const headerId = _.split(_.toLower(_.trim($(el).text())), /\s+/).join('-') + '-' + headerIdCounter
+      const headerId =
+        _.split(
+          _.toLower(
+            _.trim(
+              'header-' +
+              $(el)
+                .text()
+                .replace(/[^A-Za-z0-9]/g, ' ')
+            )
+          ),
+          /\s+/
+        ).join('-') +
+        '-' +
+        headerIdCounter
       headerIdCounter += 1
       $(el).attr({ id: headerId })
     })


### PR DESCRIPTION
Really like the table content on client view and the feature to jump to a section by clicking the header. Unfortunately this feature is missing for renderer `html-core` I did a quick update to restore this feature.