### PR TITLE
Support Baidu Tongji analytics module

### DIFF
--- a/server/modules/analytics/baidutongji/code.yml
+++ b/server/modules/analytics/baidutongji/code.yml
@@ -1,0 +1,11 @@
+head: |
+  <!-- Baidu Tongji -->
+  <script>
+    var _hmt = _hmt || [];
+    (function() {
+      var hm = document.createElement("script");
+      hm.src = "https://hm.baidu.com/hm.js?{{propertyTrackingId}}";
+      var s = document.getElementsByTagName("script")[0]; 
+      s.parentNode.insertBefore(hm, s);
+    })();
+  </script>

--- a/server/modules/analytics/baidutongji/definition.yml
+++ b/server/modules/analytics/baidutongji/definition.yml
@@ -1,0 +1,13 @@
+key: baidutongji
+title: Baidu Tongji
+description: Baidu Tongji is a web analytics service offered by Baidu that tracks and reports website traffic.
+author: requarks.io
+logo: https://static.requarks.io/logo/google-analytics.svg
+website: https://tongji.baidu.com
+isAvailable: true
+props:
+  propertyTrackingId:
+    type: String
+    title: Property Tracking ID
+    hint: https://hm.baidu.com/hm.js?XXXXXXXXXXXX
+    order: 1

--- a/server/modules/analytics/baidutongji/definition.yml
+++ b/server/modules/analytics/baidutongji/definition.yml
@@ -1,13 +1,13 @@
 key: baidutongji
 title: Baidu Tongji
 description: Baidu Tongji is a web analytics service offered by Baidu that tracks and reports website traffic.
-author: requarks.io
-logo: https://static.requarks.io/logo/google-analytics.svg
+author: lawrenceching
+logo: https://static.requarks.io/logo/baidu.svg
 website: https://tongji.baidu.com
 isAvailable: true
 props:
   propertyTrackingId:
     type: String
     title: Property Tracking ID
-    hint: https://hm.baidu.com/hm.js?XXXXXXXXXXXX
+    hint: Unique Property ID (found at the end of the tracking URL, e.g. https://hm.baidu.com/hm.js?XXXXXXXXXXXX)
     order: 1


### PR DESCRIPTION
Baidu Tongji is an alternative product to Google Analytics. It's the one largest website tracking and analytics service in China market.

--

## Test Evidence

![image](https://user-images.githubusercontent.com/12114025/66210605-cd25fd00-e6ec-11e9-8f5d-ea2b8e5e3785.png)

![image](https://user-images.githubusercontent.com/12114025/66210664-ecbd2580-e6ec-11e9-8229-2d84f0eff49a.png)
