### PR TITLE
Fix opening delete group dialog

### DIFF
--- a/client/components/admin/admin-groups-edit.vue
+++ b/client/components/admin/admin-groups-edit.vue
@@ -14,7 +14,7 @@
             v-icon mdi-arrow-left
           v-dialog(v-model='deleteGroupDialog', max-width='500', v-if='!group.isSystem')
             template(v-slot:activator='{ on }')
-              v-btn.ml-2(color='red', large, outlined, v-on='{ on }')
+              v-btn.ml-2(color='red', large, outlined, v-on='on')
                 v-icon(color='red') mdi-trash-can-outline
             v-card
               .dialog-header.is-red Delete Group?


### PR DESCRIPTION
The trash icon button in `admin-groups-edit.vue` is not working (dialog not opened when clicked). Fix syntax according to [vuetify docs](https://vuetifyjs.com/en/components/dialogs) and dialog is opened again. 

Trash button

![image](https://user-images.githubusercontent.com/3164648/66248795-4a855800-e755-11e9-90ae-c934cba4f743.png)

Vuetify docs

![image](https://user-images.githubusercontent.com/3164648/66248837-b8ca1a80-e755-11e9-931e-2a1a16698d53.png)
