### PR TITLE
Fix v-btn flat is deprecated

### DIFF
--- a/client/components/admin/admin-groups-edit.vue
+++ b/client/components/admin/admin-groups-edit.vue
@@ -21,7 +21,7 @@
               v-card-text Are you sure you want to delete group #[strong {{ group.name }}]? All users will be unassigned from this group.
               v-card-actions
                 v-spacer
-                v-btn(flat, @click='deleteGroupDialog = false') Cancel
+                v-btn(text, @click='deleteGroupDialog = false') Cancel
                 v-btn(color='red', dark, @click='deleteGroup') Delete
           v-btn.ml-2(color='success', large, depressed, @click='updateGroup')
             v-icon(left) mdi-check


### PR DESCRIPTION
After the Delete Group Modal opened I get this message

```
[Vuetify] [BREAKING] 'flat' has been removed, use 'text' instead. For more information, see the upgrade guide https://github.com/vuetifyjs/vuetify/releases/tag/v2.0.0#user-content-upgrade-guide
```

This PR will fix this.