### PR TITLE
Specify navigation visibility base on user's groups

### DIFF
--- a/client/components/admin/admin-navigation.vue
+++ b/client/components/admin/admin-navigation.vue
@@ -116,7 +116,17 @@
                     prepend-icon='search'
                     v-model='current.target'
                   )
-
+                  v-select(
+                    outlined
+                    prepend-icon='mdi-account-group'
+                    v-model="current.groups"
+                    :items="groups"
+                    item-text="name"
+                    item-value="id"
+                    label="Select Groups"
+                    multiple
+                  )
+                  .caption.pt-3.pl-5 Only groups specified can see this item. Leave blank to make item public.
                 v-card-chin
                   v-spacer
                   v-btn.px-5(color='red', outlined, @click='deleteItem(current)')
@@ -152,6 +162,7 @@ import uuid from 'uuid/v4'
 
 import treeSaveMutation from 'gql/admin/navigation/navigation-mutation-save-tree.gql'
 import treeQuery from 'gql/admin/navigation/navigation-query-tree.gql'
+import groupsQuery from 'gql/admin/users/users-query-groups.gql'
 
 import draggable from 'vuedraggable'
 
@@ -247,6 +258,14 @@ export default {
       query: treeQuery,
       fetchPolicy: 'network-only',
       update: (data) => _.cloneDeep(data.navigation.tree),
+      watchLoading (isLoading) {
+        this.$store.commit(`loading${isLoading ? 'Start' : 'Stop'}`, 'admin-navigation-tree')
+      }
+    },
+    groups: {
+      query: groupsQuery,
+      fetchPolicy: 'network-only',
+      update: (data) => data.groups.list,
       watchLoading (isLoading) {
         this.$store.commit(`loading${isLoading ? 'Start' : 'Stop'}`, 'admin-navigation-tree')
       }

--- a/client/graph/admin/navigation/navigation-query-tree.gql
+++ b/client/graph/admin/navigation/navigation-query-tree.gql
@@ -7,6 +7,7 @@
       icon
       targetType
       target
+      groups
     }
   }
 }

--- a/client/store/user.js
+++ b/client/store/user.js
@@ -10,6 +10,7 @@ const state = {
   localeCode: '',
   defaultEditor: '',
   permissions: [],
+  groups: [],
   iat: 0,
   exp: 0,
   authenticated: false
@@ -32,6 +33,7 @@ export default {
           st.localeCode = jwtData.localeCode
           st.defaultEditor = jwtData.defaultEditor
           st.permissions = jwtData.permissions
+          st.groups = jwtData.groups
           st.iat = jwtData.iat
           st.exp = jwtData.exp
           st.authenticated = true

--- a/client/themes/default/components/nav-sidebar.vue
+++ b/client/themes/default/components/nav-sidebar.vue
@@ -2,17 +2,21 @@
   v-list.py-2(dense, :class='color', :dark='dark')
     template(v-for='item of items')
       v-list-item(
-        v-if='item.kind === `link`'
+        v-if='item.kind === `link` && toShow(item)'
         :href='item.target'
         )
         v-list-item-avatar(size='24')
           v-icon {{ item.icon }}
         v-list-item-title {{ item.label }}
-      v-divider.my-2(v-else-if='item.kind === `divider`')
-      v-subheader.pl-4(v-else-if='item.kind === `header`') {{ item.label }}
+      v-divider.my-2(v-else-if='item.kind === `divider` && toShow(item)')
+      v-subheader.pl-4(v-else-if='item.kind === `header` && toShow(item)') {{ item.label }}
 </template>
 
 <script>
+
+import _ from 'lodash'
+import { get } from 'vuex-pathify'
+
 export default {
   props: {
     color: {
@@ -28,8 +32,20 @@ export default {
       default: () => []
     }
   },
+  computed: {
+    permissions: get('user/permissions'),
+    groups: get('user/groups'),
+  },
   data() {
     return {}
+  },
+  methods: {
+    toShow(item) {
+      if (!item.groups || !item.groups.length) {
+        return true
+      }
+      return _.intersection(item.groups, this.groups).length > 0
+    }
   }
 }
 </script>

--- a/server/graph/schemas/navigation.graphql
+++ b/server/graph/schemas/navigation.graphql
@@ -39,6 +39,7 @@ type NavigationItem {
   icon: String
   targetType: String
   target: String
+  groups: [Int!]
 }
 
 input NavigationItemInput {
@@ -48,4 +49,5 @@ input NavigationItemInput {
   icon: String
   targetType: String
   target: String
+  groups: [Int!]
 }


### PR DESCRIPTION
I think it would be nice if we can choose which group can see which navigation item, since there are already settings to make some pages be visible from certain user groups only.

Please let me know if I need to change something.