### PR TITLE
Actually use path variables as given in default config

### DIFF
--- a/config.sample.yml
+++ b/config.sample.yml
@@ -105,3 +105,11 @@ uploads:
 # download the offline files for sideloading.
 
 offline: false
+
+# ---------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------
+# Writeable paths for Wiki.js, mainly for cache and user uploads.
+paths:
+  content: ./content
+  data: ./data

--- a/config.sample.yml
+++ b/config.sample.yml
@@ -107,9 +107,7 @@ uploads:
 offline: false
 
 # ---------------------------------------------------------------------
-# Paths
+# Data Path
 # ---------------------------------------------------------------------
-# Writeable paths for Wiki.js, mainly for cache and user uploads.
-paths:
-  content: ./content
-  data: ./data
+# Writeable data path for Wiki.js, mainly for cache and user uploads.
+dataPath: ./data

--- a/server/app/data.yml
+++ b/server/app/data.yml
@@ -57,9 +57,7 @@ defaults:
     # System defaults
     channel: BETA
     setup: false
-    paths:
-      content: ./content
-      data: ./data
+    dataPath: ./data
     cors:
       credentials: true
       maxAge: 600

--- a/server/controllers/upload.js
+++ b/server/controllers/upload.js
@@ -11,7 +11,7 @@ const sanitize = require('sanitize-filename')
  * Upload files
  */
 router.post('/u', multer({
-  dest: path.join(WIKI.paths.data, 'uploads'),
+  dest: path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'uploads'),
   limits: {
     fileSize: WIKI.config.uploads.maxFileSize,
     files: WIKI.config.uploads.maxFiles

--- a/server/controllers/upload.js
+++ b/server/controllers/upload.js
@@ -11,7 +11,7 @@ const sanitize = require('sanitize-filename')
  * Upload files
  */
 router.post('/u', multer({
-  dest: path.join(WIKI.ROOTPATH, 'data/uploads'),
+  dest: path.join(WIKI.paths.data, 'uploads'),
   limits: {
     fileSize: WIKI.config.uploads.maxFileSize,
     files: WIKI.config.uploads.maxFiles

--- a/server/core/config.js
+++ b/server/core/config.js
@@ -70,10 +70,6 @@ module.exports = {
       }
     }
 
-    WIKI.paths = {}
-    WIKI.paths.data = path.resolve(WIKI.ROOTPATH, appconfig.paths.data)
-    WIKI.paths.content = path.resolve(WIKI.ROOTPATH, appconfig.paths.content)
-
     WIKI.config = appconfig
     WIKI.data = appdata
     WIKI.version = packageInfo.version

--- a/server/core/config.js
+++ b/server/core/config.js
@@ -70,6 +70,10 @@ module.exports = {
       }
     }
 
+    WIKI.paths = {}
+    WIKI.paths.data = path.resolve(WIKI.ROOTPATH, appconfig.paths.data)
+    WIKI.paths.content = path.resolve(WIKI.ROOTPATH, appconfig.paths.content)
+
     WIKI.config = appconfig
     WIKI.data = appdata
     WIKI.version = packageInfo.version

--- a/server/core/sideloader.js
+++ b/server/core/sideloader.js
@@ -10,7 +10,7 @@ module.exports = {
       return
     }
 
-    const sideloadExists = await fs.pathExists(path.join(WIKI.ROOTPATH, 'data/sideload'))
+    const sideloadExists = await fs.pathExists(path.join(WIKI.paths.data, 'sideload'))
 
     if (!sideloadExists) {
       return
@@ -25,16 +25,16 @@ module.exports = {
     }
   },
   async importLocales() {
-    const localeExists = await fs.pathExists(path.join(WIKI.ROOTPATH, 'data/sideload/locales.json'))
+    const localeExists = await fs.pathExists(path.join(WIKI.paths.data, 'sideload/locales.json'))
     if (localeExists) {
       WIKI.logger.info('Found locales master file. Importing locale packages...')
       let importedLocales = 0
 
-      const locales = await fs.readJson(path.join(WIKI.ROOTPATH, 'data/sideload/locales.json'))
+      const locales = await fs.readJson(path.join(WIKI.paths.data, 'sideload/locales.json'))
       if (locales && _.has(locales, 'data.localization.locales')) {
         for (const locale of locales.data.localization.locales) {
           try {
-            const localeData = await fs.readJson(path.join(WIKI.ROOTPATH, `data/sideload/${locale.code}.json`))
+            const localeData = await fs.readJson(path.join(WIKI.paths.data, `sideload/${locale.code}.json`))
             if (localeData) {
               WIKI.logger.info(`Importing ${locale.name} locale package...`)
 

--- a/server/core/sideloader.js
+++ b/server/core/sideloader.js
@@ -10,7 +10,7 @@ module.exports = {
       return
     }
 
-    const sideloadExists = await fs.pathExists(path.join(WIKI.paths.data, 'sideload'))
+    const sideloadExists = await fs.pathExists(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload'))
 
     if (!sideloadExists) {
       return
@@ -25,16 +25,16 @@ module.exports = {
     }
   },
   async importLocales() {
-    const localeExists = await fs.pathExists(path.join(WIKI.paths.data, 'sideload/locales.json'))
+    const localeExists = await fs.pathExists(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload/locales.json'))
     if (localeExists) {
       WIKI.logger.info('Found locales master file. Importing locale packages...')
       let importedLocales = 0
 
-      const locales = await fs.readJson(path.join(WIKI.paths.data, 'sideload/locales.json'))
+      const locales = await fs.readJson(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload/locales.json'))
       if (locales && _.has(locales, 'data.localization.locales')) {
         for (const locale of locales.data.localization.locales) {
           try {
-            const localeData = await fs.readJson(path.join(WIKI.paths.data, `sideload/${locale.code}.json`))
+            const localeData = await fs.readJson(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `sideload/${locale.code}.json`))
             if (localeData) {
               WIKI.logger.info(`Importing ${locale.name} locale package...`)
 

--- a/server/core/system.js
+++ b/server/core/system.js
@@ -16,7 +16,7 @@ module.exports = {
   },
   init() {
     // Clear content cache
-    fs.emptyDir(path.join(WIKI.paths.data, 'cache'))
+    fs.emptyDir(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'cache'))
 
     return this
   },

--- a/server/core/system.js
+++ b/server/core/system.js
@@ -16,7 +16,7 @@ module.exports = {
   },
   init() {
     // Clear content cache
-    fs.emptyDir(path.join(WIKI.ROOTPATH, 'data/cache'))
+    fs.emptyDir(path.join(WIKI.paths.data, 'cache'))
 
     return this
   },

--- a/server/jobs/purge-uploads.js
+++ b/server/jobs/purge-uploads.js
@@ -9,7 +9,7 @@ module.exports = async () => {
   WIKI.logger.info('Purging orphaned upload files...')
 
   try {
-    const uplTempPath = path.resolve(process.cwd(), WIKI.config.paths.data, 'uploads')
+    const uplTempPath = path.join(WIKI.paths.data, 'uploads')
     await fs.ensureDir(uplTempPath)
     const ls = await fs.readdir(uplTempPath)
     const fifteenAgo = moment().subtract(15, 'minutes')

--- a/server/jobs/purge-uploads.js
+++ b/server/jobs/purge-uploads.js
@@ -9,7 +9,7 @@ module.exports = async () => {
   WIKI.logger.info('Purging orphaned upload files...')
 
   try {
-    const uplTempPath = path.join(WIKI.paths.data, 'uploads')
+    const uplTempPath = path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'uploads')
     await fs.ensureDir(uplTempPath)
     const ls = await fs.readdir(uplTempPath)
     const fifteenAgo = moment().subtract(15, 'minutes')

--- a/server/models/assets.js
+++ b/server/models/assets.js
@@ -74,7 +74,7 @@ module.exports = class Asset extends Model {
   }
 
   async deleteAssetCache() {
-    await fs.remove(path.join(WIKI.paths.data, `cache/${this.hash}.dat`))
+    await fs.remove(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `cache/${this.hash}.dat`))
   }
 
   static async upload(opts) {
@@ -125,9 +125,9 @@ module.exports = class Asset extends Model {
 
       // Move temp upload to cache
       if (opts.mode === 'upload') {
-        await fs.move(opts.path, path.join(WIKI.paths.data, `cache/${fileHash}.dat`), { overwrite: true })
+        await fs.move(opts.path, path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `cache/${fileHash}.dat`), { overwrite: true })
       } else {
-        await fs.copy(opts.path, path.join(WIKI.paths.data, `cache/${fileHash}.dat`), { overwrite: true })
+        await fs.copy(opts.path, path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `cache/${fileHash}.dat`), { overwrite: true })
       }
 
       // Add to Storage
@@ -158,7 +158,7 @@ module.exports = class Asset extends Model {
 
   static async getAssetFromCache(assetPath, res) {
     const fileHash = assetHelper.generateHash(assetPath)
-    const cachePath = path.join(WIKI.paths.data, `cache/${fileHash}.dat`)
+    const cachePath = path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `cache/${fileHash}.dat`)
 
     return new Promise((resolve, reject) => {
       res.type(path.extname(assetPath))
@@ -174,7 +174,7 @@ module.exports = class Asset extends Model {
 
   static async getAssetFromDb(assetPath, res) {
     const fileHash = assetHelper.generateHash(assetPath)
-    const cachePath = path.join(WIKI.paths.data, `cache/${fileHash}.dat`)
+    const cachePath = path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `cache/${fileHash}.dat`)
 
     const asset = await WIKI.models.assets.query().where('hash', fileHash).first()
     if (asset) {
@@ -188,6 +188,6 @@ module.exports = class Asset extends Model {
   }
 
   static async flushTempUploads() {
-    return fs.emptyDir(path.join(WIKI.paths.data, `uploads`))
+    return fs.emptyDir(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `uploads`))
   }
 }

--- a/server/models/assets.js
+++ b/server/models/assets.js
@@ -74,7 +74,7 @@ module.exports = class Asset extends Model {
   }
 
   async deleteAssetCache() {
-    await fs.remove(path.join(process.cwd(), `data/cache/${this.hash}.dat`))
+    await fs.remove(path.join(WIKI.paths.data, `cache/${this.hash}.dat`))
   }
 
   static async upload(opts) {
@@ -125,9 +125,9 @@ module.exports = class Asset extends Model {
 
       // Move temp upload to cache
       if (opts.mode === 'upload') {
-        await fs.move(opts.path, path.join(process.cwd(), `data/cache/${fileHash}.dat`), { overwrite: true })
+        await fs.move(opts.path, path.join(WIKI.paths.data, `cache/${fileHash}.dat`), { overwrite: true })
       } else {
-        await fs.copy(opts.path, path.join(process.cwd(), `data/cache/${fileHash}.dat`), { overwrite: true })
+        await fs.copy(opts.path, path.join(WIKI.paths.data, `cache/${fileHash}.dat`), { overwrite: true })
       }
 
       // Add to Storage
@@ -158,7 +158,7 @@ module.exports = class Asset extends Model {
 
   static async getAssetFromCache(assetPath, res) {
     const fileHash = assetHelper.generateHash(assetPath)
-    const cachePath = path.join(process.cwd(), `data/cache/${fileHash}.dat`)
+    const cachePath = path.join(WIKI.paths.data, `cache/${fileHash}.dat`)
 
     return new Promise((resolve, reject) => {
       res.type(path.extname(assetPath))
@@ -174,7 +174,7 @@ module.exports = class Asset extends Model {
 
   static async getAssetFromDb(assetPath, res) {
     const fileHash = assetHelper.generateHash(assetPath)
-    const cachePath = path.join(process.cwd(), `data/cache/${fileHash}.dat`)
+    const cachePath = path.join(WIKI.paths.data, `cache/${fileHash}.dat`)
 
     const asset = await WIKI.models.assets.query().where('hash', fileHash).first()
     if (asset) {
@@ -188,6 +188,6 @@ module.exports = class Asset extends Model {
   }
 
   static async flushTempUploads() {
-    return fs.emptyDir(path.join(process.cwd(), `data/uploads`))
+    return fs.emptyDir(path.join(WIKI.paths.data, `uploads`))
   }
 }

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -728,7 +728,7 @@ module.exports = class Page extends Model {
    * @returns {Promise} Promise with no value
    */
   static async savePageToCache(page) {
-    const cachePath = path.join(WIKI.paths.data, `cache/${page.hash}.bin`)
+    const cachePath = path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `cache/${page.hash}.bin`)
     await fs.outputFile(cachePath, WIKI.models.pages.cacheSchema.encode({
       id: page.id,
       authorId: page.authorId,
@@ -757,7 +757,7 @@ module.exports = class Page extends Model {
    */
   static async getPageFromCache(opts) {
     const pageHash = pageHelper.generateHash({ path: opts.path, locale: opts.locale, privateNS: opts.isPrivate ? 'TODO' : '' })
-    const cachePath = path.join(WIKI.paths.data, `cache/${pageHash}.bin`)
+    const cachePath = path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `cache/${pageHash}.bin`)
 
     try {
       const pageBuffer = await fs.readFile(cachePath)
@@ -785,14 +785,14 @@ module.exports = class Page extends Model {
    * @returns {Promise} Promise with no value
    */
   static async deletePageFromCache(page) {
-    return fs.remove(path.join(WIKI.paths.data, `cache/${page.hash}.bin`))
+    return fs.remove(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `cache/${page.hash}.bin`))
   }
 
   /**
    * Flush the contents of the Cache
    */
   static async flushCache() {
-    return fs.emptyDir(path.join(WIKI.paths.data, `cache`))
+    return fs.emptyDir(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `cache`))
   }
 
   /**

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -728,7 +728,7 @@ module.exports = class Page extends Model {
    * @returns {Promise} Promise with no value
    */
   static async savePageToCache(page) {
-    const cachePath = path.join(process.cwd(), `data/cache/${page.hash}.bin`)
+    const cachePath = path.join(WIKI.paths.data, `cache/${page.hash}.bin`)
     await fs.outputFile(cachePath, WIKI.models.pages.cacheSchema.encode({
       id: page.id,
       authorId: page.authorId,
@@ -757,7 +757,7 @@ module.exports = class Page extends Model {
    */
   static async getPageFromCache(opts) {
     const pageHash = pageHelper.generateHash({ path: opts.path, locale: opts.locale, privateNS: opts.isPrivate ? 'TODO' : '' })
-    const cachePath = path.join(process.cwd(), `data/cache/${pageHash}.bin`)
+    const cachePath = path.join(WIKI.paths.data, `cache/${pageHash}.bin`)
 
     try {
       const pageBuffer = await fs.readFile(cachePath)
@@ -785,14 +785,14 @@ module.exports = class Page extends Model {
    * @returns {Promise} Promise with no value
    */
   static async deletePageFromCache(page) {
-    return fs.remove(path.join(process.cwd(), `data/cache/${page.hash}.bin`))
+    return fs.remove(path.join(WIKI.paths.data, `cache/${page.hash}.bin`))
   }
 
   /**
    * Flush the contents of the Cache
    */
   static async flushCache() {
-    return fs.emptyDir(path.join(process.cwd(), `data/cache`))
+    return fs.emptyDir(path.join(WIKI.paths.data, `cache`))
   }
 
   /**

--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -15,7 +15,7 @@ const commonDisk = require('../disk/common')
 
 module.exports = {
   git: null,
-  repoPath: path.join(process.cwd(), 'data/repo'),
+  repoPath: path.join(WIKI.paths.data, 'repo'),
   async activated() {
     // not used
   },
@@ -66,7 +66,7 @@ module.exports = {
         WIKI.logger.info('(STORAGE/GIT) Setting SSH Command config...')
         if (this.config.sshPrivateKeyMode === 'contents') {
           try {
-            this.config.sshPrivateKeyPath = path.join(WIKI.ROOTPATH, 'data/secure/git-ssh.pem')
+            this.config.sshPrivateKeyPath = path.join(WIKI.paths.data, 'secure/git-ssh.pem')
             await fs.outputFile(this.config.sshPrivateKeyPath, this.config.sshPrivateKeyContent, {
               encoding: 'utf8',
               mode: 0o600

--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -15,7 +15,7 @@ const commonDisk = require('../disk/common')
 
 module.exports = {
   git: null,
-  repoPath: path.join(WIKI.paths.data, 'repo'),
+  repoPath: path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'repo'),
   async activated() {
     // not used
   },
@@ -66,7 +66,7 @@ module.exports = {
         WIKI.logger.info('(STORAGE/GIT) Setting SSH Command config...')
         if (this.config.sshPrivateKeyMode === 'contents') {
           try {
-            this.config.sshPrivateKeyPath = path.join(WIKI.paths.data, 'secure/git-ssh.pem')
+            this.config.sshPrivateKeyPath = path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'secure/git-ssh.pem')
             await fs.outputFile(this.config.sshPrivateKeyPath, this.config.sshPrivateKeyContent, {
               encoding: 'utf8',
               mode: 0o600

--- a/server/setup.js
+++ b/server/setup.js
@@ -144,10 +144,9 @@ module.exports = () => {
 
       // Create directory structure
       WIKI.logger.info('Creating data directories...')
-      const dataPath = path.join(process.cwd(), 'data')
-      await fs.ensureDir(dataPath)
-      await fs.emptyDir(path.join(dataPath, 'cache'))
-      await fs.ensureDir(path.join(dataPath, 'uploads'))
+      await fs.ensureDir(WIKI.paths.data)
+      await fs.emptyDir(path.join(WIKI.paths.data, 'cache'))
+      await fs.ensureDir(path.join(WIKI.paths.data, 'uploads'))
 
       // Generate certificates
       WIKI.logger.info('Generating certificates...')

--- a/server/setup.js
+++ b/server/setup.js
@@ -144,9 +144,9 @@ module.exports = () => {
 
       // Create directory structure
       WIKI.logger.info('Creating data directories...')
-      await fs.ensureDir(WIKI.paths.data)
-      await fs.emptyDir(path.join(WIKI.paths.data, 'cache'))
-      await fs.ensureDir(path.join(WIKI.paths.data, 'uploads'))
+      await fs.ensureDir(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath))
+      await fs.emptyDir(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'cache'))
+      await fs.ensureDir(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'uploads'))
 
       // Generate certificates
       WIKI.logger.info('Generating certificates...')


### PR DESCRIPTION
According to the [defaults](https://github.com/Requarks/wiki/blob/master/server/app/data.yml#L60) one can set the data and content paths in the config file. However that wasn't used anywhere until now (besides once in `purge-uploads.js`).

I think the content path isn't used anywhere? Should I remove that one?