### PR TITLE
Expand pages.* to prevent duplicate columns in MSSQL

### DIFF
--- a/server/models/analytics.js
+++ b/server/models/analytics.js
@@ -117,7 +117,7 @@ module.exports = class Analytics extends Model {
         code.bodyEnd = _.defaultTo(code.bodyEnd, '')
 
         _.forOwn(provider.config, (value, key) => {
-          code.head = _.replace(code.head, `{{${key}}}`, value)
+          code.head = _.replace(code.head, new RegExp(`{{${key}}}`, 'g'), value)
           code.bodyStart = _.replace(code.bodyStart, `{{${key}}}`, value)
           code.bodyEnd = _.replace(code.bodyEnd, `{{${key}}}`, value)
         })

--- a/server/models/analytics.js
+++ b/server/models/analytics.js
@@ -117,7 +117,7 @@ module.exports = class Analytics extends Model {
         code.bodyEnd = _.defaultTo(code.bodyEnd, '')
 
         _.forOwn(provider.config, (value, key) => {
-          code.head = _.replace(code.head, new RegExp(`{{${key}}}`, 'g'), value)
+          code.head = _.replace(code.head, `{{${key}}}`, value)
           code.bodyStart = _.replace(code.bodyStart, `{{${key}}}`, value)
           code.bodyEnd = _.replace(code.bodyEnd, `{{${key}}}`, value)
         })

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -675,7 +675,26 @@ module.exports = class Page extends Model {
     try {
       return WIKI.models.pages.query()
         .column([
-          'pages.*',
+          'pages.id',
+          'pages.path',
+          'pages.hash',
+          'pages.title',
+          'pages.description',
+          'pages.isPrivate',
+          'pages.isPublished',
+          'pages.privateNS',
+          'pages.publishStartDate',
+          'pages.publishEndDate',
+          'pages.content',
+          'pages.render',
+          'pages.toc',
+          'pages.contentType',
+          'pages.createdAt',
+          'pages.updatedAt',
+          'pages.editorKey',
+          'pages.localeCode',
+          'pages.authorId',
+          'pages.creatorId',
           {
             authorName: 'author.name',
             authorEmail: 'author.email',


### PR DESCRIPTION
Fixes #1036
Fixes #1035

Replace pages.* in select query with explicit list of columns to avoid multiple identically named columns being returned by MSSQL triggering a graphQL error.

