### PR TITLE
Adds IDENTITY_INSERT in rebuild-tree.js #1125

### DIFF
--- a/server/jobs/rebuild-tree.js
+++ b/server/jobs/rebuild-tree.js
@@ -53,7 +53,16 @@ module.exports = async (pageId) => {
 
     await WIKI.models.knex.table('pageTree').truncate()
     if (tree.length > 0) {
-      await WIKI.models.knex.table('pageTree').insert(tree)
+      const { bindings, sql } = WIKI.models.knex.table('pageTree').insert(tree).toSQL();
+      if (WIKI.config.db.type === 'mssql') {
+        await WIKI.models.knex.raw(sql, bindings).wrap(
+          'SET IDENTITY_INSERT pageTree ON;',
+          'SET IDENTITY_INSERT pageTree OFF;',
+        )
+      } else {
+        await WIKI.models.knex.raw(sql, bindings)
+      }
+      // await WIKI.models.knex.table('pageTree').insert(tree)
     }
 
     await WIKI.models.knex.destroy()


### PR DESCRIPTION
**Fixes issue when tree is being rebuilt with mssql backend.**
I added a condition to only execute the wrapping with the IDENTITY_INSERT on an mssql type database. I already tested this fix in my docker container by modifying the files according to this pull request. The `rebuild index` is working as I expected it to work.

At the moment I do not have the time to verify other database backends, but if this is mandatory for merging this PR please let me known and I will try to validate during the next days.

Is there anything else I can do to help getting this PR into the main repo?
