### PR TITLE
remove `wikinet` network from docker-compose.yml example

### DIFF
--- a/dev/examples/docker-compose.yml
+++ b/dev/examples/docker-compose.yml
@@ -10,8 +10,6 @@ services:
       driver: "none"
     volumes:
       - db-data:/var/lib/postgresql/data
-    networks:
-      - wikinet
 
   wiki:
     image: requarks/wiki:beta
@@ -24,13 +22,8 @@ services:
       DB_USER: wikijs
       DB_PASS: wikijsrocks
       DB_NAME: wiki
-    networks:
-      - wikinet
     ports:
       - "3000:3000" # <-- replace with "80:3000" to listen on port 80 instead
-
-networks:
-  wikinet:
 
 volumes:
   db-data:


### PR DESCRIPTION
This network is unnecessary because Compose creates a network for all services by default.

