### PR TITLE
Fixed Typo in PostgreSQL

### DIFF
--- a/server/modules/search/postgres/definition.yml
+++ b/server/modules/search/postgres/definition.yml
@@ -8,7 +8,7 @@ isAvailable: true
 props:
   dictLanguage:
     type: String
-    title: Dictionnary Language
+    title: Dictionary Language
     hint: Language to use when creating and querying text search vectors.
     default: english
     enum:


### PR DESCRIPTION
Previously: "Dictionnary"
Now: "Dictionary"