### PR TITLE
Openshift/Kubernetes integration changes

### DIFF
--- a/dev/openshift/Dockerfile
+++ b/dev/openshift/Dockerfile
@@ -1,7 +1,6 @@
 FROM requarks/wiki:2
 
 # For mounting config.yml as configmap, some directory operations should be done.
-
 WORKDIR /wiki
 
 RUN mkdir config && \

--- a/dev/openshift/Dockerfile
+++ b/dev/openshift/Dockerfile
@@ -1,8 +1,8 @@
-FROM requarks/wiki:beta
+FROM requarks/wiki:2
 
-USER root
+# For mounting config.yml as configmap, some directory operations should be done.
 
-RUN chgrp -R 0 /wiki /logs && \
-    chmod -R g=u /wiki /logs
-
-USER 1001
+WORKDIR /wiki
+    mkdir config && \
+    mv config.yml config/config.yml && \
+    ln -s config/config.yml config.yml

--- a/dev/openshift/Dockerfile
+++ b/dev/openshift/Dockerfile
@@ -3,6 +3,7 @@ FROM requarks/wiki:2
 # For mounting config.yml as configmap, some directory operations should be done.
 
 WORKDIR /wiki
-    mkdir config && \
+
+RUN mkdir config && \
     mv config.yml config/config.yml && \
     ln -s config/config.yml config.yml

--- a/dev/openshift/Dockerfile
+++ b/dev/openshift/Dockerfile
@@ -7,3 +7,7 @@ WORKDIR /wiki
 RUN mkdir config && \
     mv config.yml config/config.yml && \
     ln -s config/config.yml config.yml
+
+# For offline installation, create sideload directory,then
+# mount en.json and locales.json
+RUN mkdir -p data/sideload


### PR DESCRIPTION
This merge covers Openshift/Kubernetes **configmap compatibility** for **config.yml** by changing its location to config directory. In this way, it's simple to mount config.yml as configmap.

In addition, the change includes **sideload** directory into data folder, to mount persistent volume to store locale files(at least en.json and locales.json) for offline installations.