### PR TITLE
Select Node.js and PostgreSQL version strings

### DIFF
--- a/client/components/admin/admin-system.vue
+++ b/client/components/admin/admin-system.vue
@@ -231,10 +231,7 @@ export default {
 
 <style lang='scss'>
 .admin-system {
-    .v-list-item-title {
-    user-select: text;
-  }
-  .v-list-item__subtitle {
+  .v-list-item-title, .v-list-item__subtitle {
     user-select: text;
   }
 }

--- a/client/components/admin/admin-system.vue
+++ b/client/components/admin/admin-system.vue
@@ -231,6 +231,9 @@ export default {
 
 <style lang='scss'>
 .admin-system {
+    .v-list-item-title {
+    user-select: text;
+  }
   .v-list-item__subtitle {
     user-select: text;
   }


### PR DESCRIPTION
Select Node.js and PostgreSQL version strings are now selectable
Fix #1246

