### PR TITLE
exclude non-class attributes from markdown rendering in editor preview

### DIFF
--- a/client/components/editor/editor-markdown.vue
+++ b/client/components/editor/editor-markdown.vue
@@ -233,7 +233,9 @@ const md = new MarkdownIt({
     return `<pre class="line-numbers"><code class="language-${lang}">${str}</code></pre>`
   }
 })
-  .use(mdAttrs)
+  .use(mdAttrs, {
+    allowedAttributes: ['id', 'class', 'target']
+  })
   .use(mdEmoji)
   .use(mdTaskLists, {label: true, labelAfter: true})
   .use(mdExpandTabs)


### PR DESCRIPTION
Apply fb0c64a07e9fceb457dd1c6f19896bcc73d7d77b to MD editor preview.