### PR TITLE
Failed attempt to adapt markdown-it-katex for LaTeX rendering.

### DIFF
--- a/server/modules/rendering/markdown-katex/definition.yml
+++ b/server/modules/rendering/markdown-katex/definition.yml
@@ -1,0 +1,8 @@
+key: markdownKatex
+title: Katex
+description: Convert mathematical symbols to LaTeX using KaTeX
+author: aniketpanjwani
+icon: mdi-sitemap
+enabledDefault: true
+dependsOn: markdownCore
+props: {}

--- a/server/modules/rendering/markdown-katex/package-lock.json
+++ b/server/modules/rendering/markdown-katex/package-lock.json
@@ -1,0 +1,77 @@
+{
+  "name": "markdown-katex",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@liradb2000/markdown-it-katex": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@liradb2000/markdown-it-katex/-/markdown-it-katex-2.0.7.tgz",
+      "integrity": "sha512-leHklQ6svACGXIA3DvSTynnfJvMPo0oOiRHPuYo44vXPAKJEtTv5jETp7kMcj3hehJf483E+fNX04TJWifD6RQ==",
+      "requires": {
+        "katex": "^0.11.1"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
+    "entities": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+      "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+    },
+    "katex": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.11.1.tgz",
+      "integrity": "sha512-5oANDICCTX0NqYIyAiFCCwjQ7ERu3DQG2JFHLbYOf+fXaMoH8eg/zOq5WSYJsKMi/QebW+Eh3gSM+oss1H/bww==",
+      "requires": {
+        "commander": "^2.19.0"
+      }
+    },
+    "linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "markdown-it": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
+    }
+  }
+}

--- a/server/modules/rendering/markdown-katex/package.json
+++ b/server/modules/rendering/markdown-katex/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "markdown-katex",
+  "version": "1.0.0",
+  "description": "",
+  "main": "renderer.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@liradb2000/markdown-it-katex": "^2.0.7",
+    "markdown-it": "^10.0.0"
+  }
+}

--- a/server/modules/rendering/markdown-katex/renderer.js
+++ b/server/modules/rendering/markdown-katex/renderer.js
@@ -1,0 +1,11 @@
+const mdKatex = require('@liradb2000/markdown-it-katex')
+
+// ------------------------------------
+// Markdown - Katex
+// ------------------------------------
+
+module.exports = {
+  init (md, conf) {
+    md.use(mdKatex)
+  }
+}


### PR DESCRIPTION
Hi @NGPixel - I'm not a front-end/Javascript developer, but I wanted to try implementing MathJax or KaTeX. 

I tried following the model of some of the other renderer modules (e.g. markdown-footnotes) to create the boilerplate to create a KaTeX module using this npm package: [markdown-it-katex](https://github.com/waylonflinn/markdown-it-katex) (or specifically [this updated fork](https://www.npmjs.com/package/@liradb2000/markdown-it-katex)).

My naive implementation does _something_, but I don't get any image rendering. I took a look at @ethanmdavidson's implementation of the PlantUML renderer module, but it's a bit beyond my current Javascript abilities to decipher.

Anyway - I understand you've got many more features to attend to for 2.1, but if someone else wants to build on this (or help me work on it), that would be great.

Here are some pictures of current behavior:

![image](https://user-images.githubusercontent.com/16311215/71058574-e522ef80-2125-11ea-92bb-7a0c88307a9d.png)

![image](https://user-images.githubusercontent.com/16311215/71058593-f23fde80-2125-11ea-920a-56adadd82180.png)
