### PR TITLE
fix: getPagePath returns trailing slash on locale (#1323)

### DIFF
--- a/server/helpers/page.js
+++ b/server/helpers/page.js
@@ -4,7 +4,7 @@ const crypto = require('crypto')
 const path = require('path')
 
 const localeSegmentRegex = /^[A-Z]{2}(-[A-Z]{2})?$/i
-const localeFolderRegex = /^([a-z]{2}(?:-[a-z]{2})?\/)?(.*)/i
+const localeFolderRegex = /^([a-z]{2}(?:-[a-z]{2})?)\/?(.*)/i
 
 const contentToExt = {
   markdown: 'md',


### PR DESCRIPTION
This excludes the trailing slash from the locale code.

