### PR TITLE
fix: rebuild-tree exceeds mssql's parameter limit

### DIFF
--- a/server/jobs/rebuild-tree.js
+++ b/server/jobs/rebuild-tree.js
@@ -53,7 +53,9 @@ module.exports = async (pageId) => {
 
     await WIKI.models.knex.table('pageTree').truncate()
     if (tree.length > 0) {
-      await WIKI.models.knex.table('pageTree').insert(tree)
+      for (const chunk of _.chunk(tree, 100)) {
+        await WIKI.models.knex.table('pageTree').insert(chunk)
+      }
     }
 
     await WIKI.models.knex.destroy()

--- a/server/jobs/rebuild-tree.js
+++ b/server/jobs/rebuild-tree.js
@@ -53,6 +53,7 @@ module.exports = async (pageId) => {
 
     await WIKI.models.knex.table('pageTree').truncate()
     if (tree.length > 0) {
+      // -> Save in chunks, because of per query max parameters (35k Postgres, 2k MSSQL, 1k for SQLite)
       for (const chunk of _.chunk(tree, 100)) {
         await WIKI.models.knex.table('pageTree').insert(chunk)
       }


### PR DESCRIPTION
MSSQL has a limit of 2100 parameters per query. With 10 fields per insert, there is a rough maximum of 200 inserts per query. I opted for 100 here just to be safe, but still performant.