### PR TITLE
Fixes #1318

### DIFF
--- a/server/modules/rendering/html-core/renderer.js
+++ b/server/modules/rendering/html-core/renderer.js
@@ -39,8 +39,9 @@ module.exports = {
     $('a').each((i, elm) => {
       let href = $(elm).attr('href')
 
-      // -> Ignore empty / anchor links
-      if (!href || href.length < 1 || href.indexOf('#') === 0 || href.indexOf('mailto:') === 0) {
+      // -> Ignore empty / anchor links, e-mail addresses, and telephone numbers
+      if (!href || href.length < 1 || href.indexOf('#') === 0 ||
+        href.indexOf('mailto:') === 0 || href.indexOf('tel:') === 0) {
         return
       }
 


### PR DESCRIPTION
Telephone links will no longer be incorrectly parsed as web links.

Signed-off-by: Scott Simontis <yo@scottsimontis.io>

