### PR TITLE
fix: allow highlight color

### DIFF
--- a/server/modules/rendering/html-security/renderer.js
+++ b/server/modules/rendering/html-security/renderer.js
@@ -19,6 +19,7 @@ module.exports = {
           h6: ['class', 'id', 'style'],
           img: ['alt', 'class', 'draggable', 'height', 'src', 'style', 'width'],
           li: ['class', 'style'],
+          mark: ['class', 'style'],
           ol: ['class', 'style'],
           p: ['class', 'style'],
           path: ['d', 'style'],


### PR DESCRIPTION
The highlight feature in wysiwyg adds `<mark class="pen-red">`, but html security trips out the `class` attribute. This allows `class` and `style` for good measure, and chameleon coding. 