### PR TITLE
fix: light background in nested ckeditor unless dark mode

### DIFF
--- a/client/components/editor/editor-ckeditor.vue
+++ b/client/components/editor/editor-ckeditor.vue
@@ -179,7 +179,11 @@ $editor-height-mobile: calc(100vh - 56px - 16px);
     &.ck .ck-editor__nested-editable:focus,
     .ck-widget.table td.ck-editor__nested-editable.ck-editor__nested-editable_focused,
     .ck-widget.table th.ck-editor__nested-editable.ck-editor__nested-editable_focused {
-      background-color: mc('grey', '900');
+      background-color: mc('grey', '100');
+
+      @at-root .theme--dark & {
+        background-color: mc('grey', '900');
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes this issue:

![image](https://user-images.githubusercontent.com/2042102/72275615-1e466680-35e3-11ea-9000-a992f492d4d6.png)
