### PR TITLE
Added Env-Variable for logLevel

### DIFF
--- a/dev/build/config.yml
+++ b/dev/build/config.yml
@@ -15,4 +15,4 @@ ssl:
   provider: letsencrypt
   domain: $(LETSENCRYPT_DOMAIN)
   subscriberEmail: $(LETSENCRYPT_EMAIL)
-logLevel: info
+logLevel: $(LOG_LEVEL)


### PR DESCRIPTION
Added Env-Variable LOG_LEVEL to set logLevel in config.yaml on Docker-based installations.

Disclaimer: I don't know if this edit could have unintended consequences for other installation options. Could only test it on Docker.

