### PR TITLE
fix: alter pageHistory content data type to LONGTEXT (#1294)

### DIFF
--- a/server/db/beta/migrations/2.0.0-rc.29.js
+++ b/server/db/beta/migrations/2.0.0-rc.29.js
@@ -15,6 +15,17 @@ exports.up = knex => {
           break
       }
     })
+    .table('pageHistory', table => {
+      switch (WIKI.config.db.type) {
+        case 'mariadb':
+        case 'mysql':
+          table.specificType('content', 'LONGTEXT').alter()
+          break
+        case 'mssql':
+          table.specificType('content', 'VARCHAR(max)').alter()
+          break
+      }
+    })
 }
 
 exports.down = knex => { }

--- a/server/db/migrations/2.0.0.js
+++ b/server/db/migrations/2.0.0.js
@@ -125,7 +125,19 @@ exports.up = knex => {
       table.string('publishEndDate')
       table.string('action').defaultTo('updated')
       table.integer('pageId').unsigned()
-      table.text('content')
+      switch (WIKI.config.db.type) {
+        case 'postgres':
+        case 'sqlite':
+          table.text('content')
+          break
+        case 'mariadb':
+        case 'mysql':
+          table.specificType('content', 'LONGTEXT')
+          break
+        case 'mssql':
+          table.specificType('content', 'VARCHAR(max)')
+          break
+      }
       table.string('contentType').notNullable()
       table.string('createdAt').notNullable()
     })


### PR DESCRIPTION
Per @NGPixel in #1294, the column data type for `pageHistory.content` should be initialized as `LONGTEXT`. This fix affects only new installs and new migrations. For existing installs, either wiki admins will be expected to fix the column type in their databases, or a "validate and fix schema" option will need to be added to the Utilities menu.