### PR TITLE
Fix list formatting multiline with fancy bullets

### DIFF
--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -487,7 +487,7 @@ ul {
       > p {
         display:inline-block;
         vertical-align:top;
-        padding-top:0!important;
+        padding-top:0;
       }
   }
   }

--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -475,11 +475,15 @@
 ul {
     list-style: none;
     width: 100%;
-    > li::before {		
-      content: '\25b8';		
-      color: mc('grey', '600');		
-      display: inline-block;		
-      width: 1.35rem;		
+    > li::before {
+      content: '\25b8';
+      color: mc('grey', '600');
+      display: inline-block;
+      width: 1.35rem;
+      
+      @at-root .is-rtl & {
+        content: '\25C0' ;
+      }
     }
     > li {
       display:flex;

--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -312,8 +312,8 @@
   // ---------------------------------
 
   ol, ul {
-    padding: 1rem 0 0 1rem;
-    list-style-position: outside;
+	  padding: 1rem 0 0 0;
+     list-style-position: inside;
 
     @at-root .is-rtl & {
       padding-left: 0;
@@ -472,8 +472,24 @@
     }
   }
 
-  ul {
-    list-style: square outside;
+ul {
+    list-style: none;
+    width: 100%;
+    > li::before {		
+      content: '\25b8';		
+      color: mc('grey', '600');		
+      display: inline-block;		
+      width: 1.35rem;		
+    }
+    > li {
+      display:flex;
+      flex-wrap: wrap;
+      > p {
+        display:inline-block;
+        vertical-align:top;
+        padding-top:0!important;
+      }
+  }
   }
 
   // ---------------------------------


### PR DESCRIPTION
In kinda response to: Requarks#1283 because i kinda like the fancy bullets so i propose a alternative solution that solves the problem with the list having issues with p elements and with multi lines but keeping the fancy css bullets.

Tested on Chrome, Firefox, Opera and Edge.
image of it working on chrome:
![chrome_2020-01-22_14-55-47](https://user-images.githubusercontent.com/16158418/72900456-2e1f2280-3d28-11ea-875f-18b0af75b949.png)
and image of it working on firefox:
![firefox_2020-01-22_15-11-36](https://user-images.githubusercontent.com/16158418/72901179-8c98d080-3d29-11ea-960d-abc2489cab14.png)

I did not include screenshots of the other because i believe that showing this may be enough, but i can provide it if needed

I have 2 alternative css for the p like 

```scss
  > p {
        display:inline-table;
      }
```
or
```scss
  > p {
        display:inline-flex;
      }
```
i just choose to use 
```scss
  > p {
        display:inline-block;
        vertical-align:top;
        padding-top:0!important;
      }

```
because i believe that it has more cross browser compatibility, but science for the other fixes i already had to use flex it may not matter.