### PR TITLE
Adding an override for the ssh port

### DIFF
--- a/server/modules/storage/git/definition.yml
+++ b/server/modules/storage/git/definition.yml
@@ -94,11 +94,11 @@ props:
     hint: Optional - Absolute path to the Git binary, when not available in PATH. Leave empty to use the default PATH location (recommended).
     order: 50
   sshPort:
-    type: Integer
-    title: Ssh port
-    default: '22'
-    hint: Optional - Allows overriding ssh default port.
-    order: 51
+    type: Number
+    title: SSH Port
+    default: 22
+    hint: Optional - SSH Authentication Only - Allows overriding ssh default port.
+    order: 60
 actions:
   - handler: syncUntracked
     label: Add Untracked Changes

--- a/server/modules/storage/git/definition.yml
+++ b/server/modules/storage/git/definition.yml
@@ -93,6 +93,12 @@ props:
     default: ''
     hint: Optional - Absolute path to the Git binary, when not available in PATH. Leave empty to use the default PATH location (recommended).
     order: 50
+  sshPort:
+    type: Integer
+    title: Ssh port
+    default: '22'
+    hint: Optional - Allows overriding ssh default port.
+    order: 51
 actions:
   - handler: syncUntracked
     label: Add Untracked Changes

--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -77,7 +77,10 @@ module.exports = {
             throw err
           }
         }
-        await this.git.addConfig('core.sshCommand', `ssh -i "${this.config.sshPrivateKeyPath}" -o StrictHostKeyChecking=no`)
+        if (this.config.sshPort <= 0) {
+            this.config.sshPort = 22
+        } 
+        await this.git.addConfig('core.sshCommand', `ssh -i "${this.config.sshPrivateKeyPath}" -o StrictHostKeyChecking=no -p ${this.config.sshPort}`)
         WIKI.logger.info('(STORAGE/GIT) Adding origin remote via SSH...')
         await this.git.addRemote('origin', this.config.repoUrl)
         break


### PR DESCRIPTION
Problem:
- Trying to use git storage feature with a private git server with ssh running on a non-default port.  Git over ssh typically happens on port 22 however non-standard setups can use a custom port number.  Wiki.js doesn't support adding custom SSH port while setting up the git storage.

Solution:
- Added an option on the git storage configuration page to allow specifying ssh port.  It is optional and empty by default with port 22 used by default if nothing specified.

Testing:
- Manually validated that the setting is properly picked up.
- Tested with custom and default ports and everything worked as expected.

Possible future improvement:
- Adding an advanced ssh section on the git storage page and rolling this configuration into that would be a possible way of simplifying the UI.