### PR TITLE
fix: apply json size limit to graphql

### DIFF
--- a/server/master.js
+++ b/server/master.js
@@ -84,6 +84,7 @@ module.exports = async () => {
   // GraphQL Server
   // ----------------------------------------
 
+  app.use(bodyParser.json({ limit: '1mb' }))
   await WIKI.servers.startGraphQL()
 
   // ----------------------------------------
@@ -99,7 +100,6 @@ module.exports = async () => {
   app.set('views', path.join(WIKI.SERVERPATH, 'views'))
   app.set('view engine', 'pug')
 
-  app.use(bodyParser.json({ limit: '1mb' }))
   app.use(bodyParser.urlencoded({ extended: false, limit: '1mb' }))
 
   // ----------------------------------------


### PR DESCRIPTION
This applies the 1mb size limit to graphql by placing the body-parser statement prior to graphql. 