### PR TITLE
fix: dev/examples/docker-compose.yml mapped ports

### DIFF
--- a/dev/examples/docker-compose.yml
+++ b/dev/examples/docker-compose.yml
@@ -26,8 +26,8 @@ services:
       DB_NAME: wiki
     restart: unless-stopped
     ports:
-      - "80:3000"
-      - "443:3443"
+      - "3000:3000"
+      - "3443:3443"
 
 volumes:
   db-data:


### PR DESCRIPTION
Hi,

I was trying out wiki.js by using the file at `dev/examples/docker-compose.yml`. But the ports aren't correctly mapped for the default configuration of the wiki server. From what I can see, the server serves on port 3000 and 3443 by default but the current port mappings would make you think that the wiki is serving on port 80 and 443 and mapping to port 3000 and 3443 on the host.

Not sure if the intent was to expose port 3000 and 3443 to 80 and 443 on the host. If that's the case, reversing the order to
```
      - "3000:80"
      - "3443:443"
```

Would also work, but for an example docker-compose file wouldn't be very practical. So I suggest to simply map the default ports on the host as the change suggested.

Thanks for reading and considering my PR 😄 

Sorry for the long winded explanation