### PR TITLE
Admin -> Pages -> Edit Path -> Save/Update

### DIFF
--- a/client/components/admin/admin-pages-edit.vue
+++ b/client/components/admin/admin-pages-edit.vue
@@ -189,7 +189,6 @@ import _ from 'lodash'
 import { StatusIndicator } from 'vue-status-indicator'
 import gql from 'graphql-tag'
 
-import localesQuery from 'gql/admin/locale/locale-query-list.gql'
 import pageQuery from 'gql/admin/pages/pages-query-single.gql'
 import deletePageMutation from 'gql/common/common-pages-mutation-delete.gql'
 
@@ -202,17 +201,11 @@ export default {
       deletePageDialog: false,
       page: {},
       loading: false,
-      locales: [],
       selectedLocale: 'en',
       editPop: {
         path: false,
         timezone: false
       }
-    }
-  },
-  computed: {
-    installedLocales() {
-      return _.filter(this.locales, ['isInstalled', true])
     }
   },
   methods: {
@@ -272,7 +265,7 @@ export default {
      * Update the current page
      */
     async updatePage() {
-      this.$store.commit(`loadingStart`, 'admin-users-update')
+      this.$store.commit(`loadingStart`, 'page-update')
       try {
         let resp = await this.$apollo.mutate({
           mutation: gql`
@@ -317,7 +310,7 @@ export default {
         })
         throw err
       }
-      this.$store.commit(`loadingStop`, 'admin-users-update')
+      this.$store.commit(`loadingStop`, 'page-update')
     }
   },
   apollo: {
@@ -332,14 +325,6 @@ export default {
       update: (data) => data.pages.single,
       watchLoading (isLoading) {
         this.$store.commit(`loading${isLoading ? 'Start' : 'Stop'}`, 'admin-pages-refresh')
-      }
-    },
-    locales: {
-      query: localesQuery,
-      fetchPolicy: 'network-only',
-      update: (data) => data.localization.locales.map(lc => ({ ...lc, isDownloading: false })),
-      watchLoading (isLoading) {
-        this.$store.commit(`loading${isLoading ? 'Start' : 'Stop'}`, 'admin-locale-refresh')
       }
     }
   }

--- a/client/components/admin/admin-pages-edit.vue
+++ b/client/components/admin/admin-pages-edit.vue
@@ -80,23 +80,8 @@
                   left
                   )
                   template(v-slot:activator='{ on }')
-                    v-btn(icon, color='grey', x-small, v-on='on', @click='focusField(`iptLocale`)')
+                    v-btn(icon, color='grey', x-small, v-on='on', @click='editLocale')
                       v-icon mdi-pencil
-                  v-card
-                    v-select(
-                      ref='iptLocale'
-                      :items='installedLocales'
-                      :label='$t(`admin:locale.title`)'
-                      v-model="page.locale"
-                      item-text='code'
-                      solo
-                      dense
-                      hide-details
-                      append-icon='mdi-check'
-                      @click:append='editPop.timezone = false'
-                      @keydown.enter='editPop.timezone = false'
-                      @keydown.esc='editPop.timezone = false'
-                    )
             v-divider
             v-list-item
               v-list-item-content
@@ -272,6 +257,16 @@ export default {
       })
     },
     /**
+     * Edit locale
+     */
+    editLocale () {
+      this.$store.commit('showNotification', {
+        style: 'indigo',
+        message: `Coming soon...`,
+        icon: 'directions_boat'
+      })
+    },
+    /**
      * Focus an input after delay
      */
     focusField (ipt) {
@@ -282,31 +277,26 @@ export default {
       })
     },
     /**
-     * Update a page
+     * Update the current page
      */
     async updatePage() {
       try {
-        let respContent = await this.$apollo.mutate({
+        let respUpdatePage = await this.$apollo.mutate({
           mutation: gql`
-            query($id: Int!){
+            mutation($id: Int!, $path: String) {
               pages {
-                single(id:$id){
-                  content
+                update(id:$id, path: $path) {
+                  responseResult {
+                    message
+                    errorCode
+                    slug
+                  }
                 }
               }
             }
           `,
           variables: {
-            id: this.page.id
-          }
-        })
-        let content = _.get(respContent, 'data.pages.single.content', false)
-        let respUpdatePage = await this.$apollo.mutate({
-          mutation: updatePageMutation,
-          variables: {
             id: this.page.id,
-            content: content,
-            locale: this.page.locale,
             path: this.page.path
           }
         })

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -318,8 +318,10 @@ module.exports = class Page extends Model {
     }
 
     // -> Check for empty content
-    if (!opts.content || _.trim(opts.content).length < 1) {
-      throw new WIKI.Error.PageEmptyContent()
+    if (opts.content) {
+      if (_.trim(opts.content).length < 1) {
+        throw new WIKI.Error.PageEmptyContent()
+      }
     }
 
     // -> Create version snapshot

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -346,8 +346,11 @@ module.exports = class Page extends Model {
       isPrivate: ogPage.isPrivate
     })
 
-    // -> Save Tags
-    await WIKI.models.tags.associateTags({ tags: opts.tags, page })
+    // -> Update only if there is a reason to do that
+    if (opts.tags) {
+      // -> Save Tags
+      await WIKI.models.tags.associateTags({tags: opts.tags, page})
+    }
 
     // -> Render page to HTML
     await WIKI.models.pages.renderPage(page)


### PR DESCRIPTION
**Reasoning for Pull Request:**
As i was confused by the edit icons for the path and locale when editing a page, i decided to add some function to it.

**Changes:**
For now, i added a "coming soon" notification to the locale edit icon and focused on the path editing only. But i prepared a bit for adding locale editing in the near future.
When clicking the path edit icon, the user will be presented with a input field. The user can then edit the path to his liking.
After editing the path, the user will need to save the changes. I added a "Update Page" Button to the top right of the page.
Pressing that button will save the changed path to the database.
For editing other values on that page, it is now very easy to add more editable values in the future.

**Code clarification:**
For some reason, when trying to update the page through a mutation, i was told that the page content can not be empty. That doesnt really make sense when editing only the path, so i made it possible to edit the page without providing page-content.

I also ran into an error, when editing the page, because of the tags.
Sorrounding the `associateTags-call` with a simple "if" solved the issue.

**Locales:**
As i had to add some new texts, these are the language keys i added:
```
common:
  page.updatePage: 'Update Page'
  page.pageUpdateSuccess: 'Page updated successfully.'
```

Best Regards,
CubE :)