### PR TITLE
Option to restrict Discord auth to a specific server

### DIFF
--- a/server/modules/authentication/discord/authentication.js
+++ b/server/modules/authentication/discord/authentication.js
@@ -5,6 +5,7 @@
 // ------------------------------------
 
 const DiscordStrategy = require('passport-discord').Strategy
+const _ = require('lodash')
 
 module.exports = {
   init (passport, conf) {
@@ -14,9 +15,12 @@ module.exports = {
         clientSecret: conf.clientSecret,
         authorizationURL: 'https://discordapp.com/api/oauth2/authorize?prompt=none',
         callbackURL: conf.callbackURL,
-        scope: 'identify email'
+        scope: 'identify email guilds'
       }, async (accessToken, refreshToken, profile, cb) => {
         try {
+		  if (conf.guildId && !_.some(profile.guilds, { id: conf.guildId })) {
+            throw new WIKI.Error.AuthLoginFailed()
+          }
           const user = await WIKI.models.users.processProfile({
             profile: {
               ...profile,

--- a/server/modules/authentication/discord/authentication.js
+++ b/server/modules/authentication/discord/authentication.js
@@ -18,7 +18,7 @@ module.exports = {
         scope: 'identify email guilds'
       }, async (accessToken, refreshToken, profile, cb) => {
         try {
-		  if (conf.guildId && !_.some(profile.guilds, { id: conf.guildId })) {
+		      if (conf.guildId && !_.some(profile.guilds, { id: conf.guildId })) {
             throw new WIKI.Error.AuthLoginFailed()
           }
           const user = await WIKI.models.users.processProfile({

--- a/server/modules/authentication/discord/definition.yml
+++ b/server/modules/authentication/discord/definition.yml
@@ -18,3 +18,8 @@ props:
     title: Client Secret
     hint: Application Client Secret
     order: 2
+  guildId:
+    type: String
+    title: Server ID
+    hint: Optional - Your unique server identifier, such that only members are authorized
+    order: 3


### PR DESCRIPTION
Very small feature to optionally restrict discord authentication to members of a specific server. We use this in our wiki, maybe it could be useful to others.