### PR TITLE
fix: Resolve Twitch OAuth API - fixes #1268

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "passport-okta-oauth": "0.0.1",
     "passport-openidconnect": "0.0.2",
     "passport-saml": "1.3.3",
-    "passport-twitch": "1.0.3",
+    "passport-twitch-oauth": "1.0.0",
     "pem-jwk": "2.0.0",
     "pg": "7.18.2",
     "pg-hstore": "2.3.3",

--- a/server/modules/authentication/twitch/authentication.js
+++ b/server/modules/authentication/twitch/authentication.js
@@ -4,7 +4,7 @@
 // Twitch Account
 // ------------------------------------
 
-const TwitchStrategy = require('passport-twitch').Strategy
+const TwitchStrategy = require('passport-twitch-oauth').Strategy
 const _ = require('lodash')
 
 module.exports = {
@@ -19,7 +19,7 @@ module.exports = {
           const user = await WIKI.models.users.processProfile({
             profile: {
               ...profile,
-              picture: _.get(profile, '_json.logo', '')
+              picture: _.get(profile, 'avatar', '')
             },
             providerKey: 'twitch'
           })

--- a/server/modules/authentication/twitch/definition.yml
+++ b/server/modules/authentication/twitch/definition.yml
@@ -8,7 +8,7 @@ website: https://dev.twitch.tv/docs/authentication/
 isAvailable: true
 useForm: false
 scopes:
-  - user_read
+  - 'user:read:email'
 props:
   clientId:
     type: String


### PR DESCRIPTION
The current Node module which is used for Twitch authentication hasn't been updated in a very long time. It's using the old method of obtaining user credentials. There is a new module, passport-twitch-oauth, which uses the correct endpoints. 

The scope requested has been updated for this new spec, and the profile image has moved location as well.

As for testing I confirmed by spinning up the docker image and testing the login locally.