### PR TITLE
fix: Correct Postgres 2.2.17 migration

### DIFF
--- a/server/db/migrations/2.2.17.js
+++ b/server/db/migrations/2.2.17.js
@@ -5,7 +5,7 @@ exports.up = knex => {
   switch (WIKI.config.db.type) {
     case 'postgres':
     case 'mssql':
-      sqlVersionDate = 'UPDATE "pageHistory" h1 SET "versionDate" = COALESCE((SELECT prev."createdAt" FROM "pageHistory" prev WHERE prev."pageId" = h1."pageId" AND prev.id < h1.id ORDER BY prev.id DESC LIMIT 1), h1.createdAt)'
+      sqlVersionDate = 'UPDATE "pageHistory" h1 SET "versionDate" = COALESCE((SELECT prev."createdAt" FROM "pageHistory" prev WHERE prev."pageId" = h1."pageId" AND prev.id < h1.id ORDER BY prev.id DESC LIMIT 1), h1."createdAt")'
       break
     case 'mysql':
     case 'mariadb':


### PR DESCRIPTION
Missing quotes causes issues trying to migrate data.

h1.createdAt get parsed as h1.createdat casing the query to fail due to the column not being found.