### PR TITLE
fix: Update docker configuration file location

### DIFF
--- a/server/core/config.js
+++ b/server/core/config.js
@@ -19,7 +19,7 @@ module.exports = {
     }
 
     if (process.env.dockerdev) {
-      confPaths.config = path.join(WIKI.ROOTPATH, `dev/docker-${process.env.DEVDB}/config.yml`)
+      confPaths.config = path.join(WIKI.ROOTPATH, `dev/containers/config.yml`)
     }
 
     if (process.env.CONFIG_FILE) {


### PR DESCRIPTION
Updates the location of "config.yml" from the old database type related location to the new "containers" location.

Related to #1533