### PR TITLE
Fix rendering of unordered lists and footnotes

### DIFF
--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -476,12 +476,12 @@
     > li::before {
       position: absolute;
       left: -1.1rem;
-      content: '\26AB';
+      content: '\25b8';
       color: mc('grey', '600');
       width: 1.35rem;
 
       @at-root .is-rtl & {
-        content: '•' ;
+        content: '\25C3';
       }
     }
   }

--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -313,7 +313,6 @@
   ol, ul {
     padding-top: 1rem;
     width: 100%;
-    // list-style-position: inside;
 
     @at-root .is-rtl & {
       padding-left: 0;

--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -198,7 +198,6 @@
   p {
     padding: 1rem 0 0 0;
     margin: 0;
-    text-align: justify;
 
     @at-root .contents > div > p:first-child {
       padding-top: 0;
@@ -312,8 +311,9 @@
   // ---------------------------------
 
   ol, ul {
-    padding: 1rem 0 0 0;
-    list-style-position: inside;
+    padding-top: 1rem;
+    width: 100%;
+    // list-style-position: inside;
 
     @at-root .is-rtl & {
       padding-left: 0;
@@ -474,18 +474,21 @@
 
   ul {
     list-style: none;
-    width: 100%;
     > li::before {
-      content: '\25b8';
+      position: absolute;
+      left: -1.1rem;
+      content: '\26AB';
       color: mc('grey', '600');
-      display: inline-block;
       width: 1.35rem;
 
       @at-root .is-rtl & {
-        content: '\25C3' ;
+        content: '•' ;
       }
     }
+  }
+  ul, ol {
     > li {
+      position: relative;
       > p {
         display:inline-block;
         vertical-align:top;


### PR DESCRIPTION
This is fixing #898, #1602, and the list part of #1577.

No effects on other list features were found.

---

Markdown source and screenshot of render:

```markdown
## Unordered list without extra line breaks

- List item
  - Indented list item
    - Indented list item
- List item with long text.  List item with long text. List item with long text. List item with long text. List item with long text. List item with long text. List item with long text. 
- List item

## Unordered list with extra line breaks
- List item

  - Indented list item

    - Indented list item

- List item with long text.  List item with long text. List item with long text. List item with long text. List item with long text. List item with long text. List item with long text.[^fn1]

[^fn1]: The first footnote

- List item[^fn2]

[^fn2]: The second footnote with a longer text

## Ordered list

1. List item
   1. Indented list item
2. List item

## Link list

- [A link *with description*](/)
- [A link *with description*](/)
{.links-list}

## Grid list

- List item.
- List item with long text.  List item with long text. List item with long text. List item with long text. List item with long text. List item with long text. List item with long text.
{.grid-list}
```

![image](https://user-images.githubusercontent.com/571494/77246089-2692d180-6c24-11ea-8f23-d76601e17310.png)



