### PR TITLE
Acitvated scrolling for page tree visualisation

### DIFF
--- a/client/components/admin/admin-pages-visualize.vue
+++ b/client/components/admin/admin-pages-visualize.vue
@@ -371,6 +371,7 @@ export default {
 <style lang='scss'>
 .admin-pages-visualize-svg {
   text-align: center;
+  overflow-x: scroll;
 
   > svg {
     height: 100vh;


### PR DESCRIPTION
In chrome, the tree visualisation is scrollable on the y axis, but not on the x-axis. This PR makes the tree visualisation scrollable on the x-axis as well. This is a quick fix, there might be a better position and a more suitable place for the css than proposed with this pull request. If this is the case, let me know or simply edit it.

