### PR TITLE
fix: media print css

### DIFF
--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -798,12 +798,15 @@
 @media print {
   .nav-header,
   .v-navigation-drawer,
-  .v-footer,
   .v-btn--fab,
   .page-col-sd,
   .v-tooltip__content
   {
     display: none !important;
+  }
+
+  .layout {
+    display: block !important;
   }
 
   .page-col-content {


### PR DESCRIPTION
This fixes copyright footer for printing related to issue #1593 , and probably fixes firefox print problem (#1034).

**Screenshot**
![compare2](https://user-images.githubusercontent.com/18533151/79061230-d78f0800-7cc8-11ea-93b8-0e3964971eb1.png)