### PR TITLE
fix: editor-modal-media action button

### DIFF
--- a/client/components/editor/editor-modal-media.vue
+++ b/client/components/editor/editor-modal-media.vue
@@ -80,7 +80,7 @@
                     td(v-if='$vuetify.breakpoint.smAndUp')
                       v-menu(offset-x, min-width='200')
                         template(v-slot:activator='{ on }')
-                          v-btn(icon, v-on='on', tile, small)
+                          v-btn(icon, v-on='on', tile, small, @click.left='currentFileId = props.item.id')
                             v-icon(color='grey darken-2') mdi-dots-horizontal
                         v-list(nav, style='border-top: 5px solid #444;')
                           v-list-item(@click='', disabled)


### PR DESCRIPTION
This fixes editor-modal-media action button related to #1493 .

**Screenshot**
![after](https://user-images.githubusercontent.com/18533151/79568081-318c3500-80f0-11ea-8592-08347f1711b9.gif)