### PR TITLE
Fix #1692 : Properly wrap very long words in markdown editor

### DIFF
--- a/client/components/editor/editor-markdown.vue
+++ b/client/components/editor/editor-markdown.vue
@@ -830,6 +830,10 @@ $editor-height-mobile: calc(100vh - 112px - 16px);
     }
   }
 
+  .CodeMirror-wrap pre.CodeMirror-line, .CodeMirror-wrap pre.CodeMirror-line-like {
+    word-break: break-word;
+  }
+
   .CodeMirror-focused .cm-matchhighlight {
     background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAFklEQVQI12NgYGBgkKzc8x9CMDAwAAAmhwSbidEoSQAAAABJRU5ErkJggg==);
     background-position: bottom;

--- a/client/components/editor/editor-markdown.vue
+++ b/client/components/editor/editor-markdown.vue
@@ -740,6 +740,10 @@ $editor-height-mobile: calc(100vh - 112px - 16px);
       @include until($tablet) {
         height: $editor-height-mobile;
       }
+
+      p.line {
+        overflow-wrap: break-word;
+      }
     }
   }
 


### PR DESCRIPTION
Fix #1692, where the width of the markdown editor and the preview increases relating to the word-length.

Apply `break-word` instead of `normal` for words in the editor, which allows words to be broken, if they get too long.
```css
.CodeMirror-wrap pre.CodeMirror-line, .CodeMirror-wrap pre.CodeMirror-line-like {
    word-break: break-word;
}
```

Apply `break-word` to the `overflow-wrap` of the preview of the markdown editor, so long words do not overflow out of the screen to the right.
```css
.editor-markdown {
    /* ... */
    &-preview {
        /* ... */
        &-content {
            /* ... */
            p.line {
                overflow-wrap: break-word; 
            }
        }
    }
}
```