### PR TITLE
Default link for new external link is now empty

### DIFF
--- a/client/components/admin/admin-navigation.vue
+++ b/client/components/admin/admin-navigation.vue
@@ -311,7 +311,7 @@ export default {
             label: this.$t('navigation.untitled', { kind: this.$t(`navigation.link`) }),
             icon: 'mdi-chevron-right',
             targetType: 'home',
-            target: '/'
+            target: ''
           }
           break
         case 'header':


### PR DESCRIPTION
Default link for new external link is now empty instead of '/'

fix #1747 

