### PR TITLE
Fix #1470 move page failed with page rules

### DIFF
--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -400,8 +400,8 @@ module.exports = class Page extends Model {
 
     // -> Check for source page access
     if (!WIKI.auth.checkAccess(opts.user, ['manage:pages'], {
-      locale: page.sourceLocale,
-      path: page.sourcePath
+      locale: page.localeCode,
+      path: page.path
     })) {
       throw new WIKI.Error.PageMoveForbidden()
     }


### PR DESCRIPTION
There is a bug mention at #1470. While the server tries to compare the page permission with the page rules, `page.sourceLocale` or `page.sourcePath` is not defined in the `page` object. The actual one must be `page.localeCode` and `page.path`. Otherwise, the `checkAccess()` function will compare `undefined` with page rules.