### PR TITLE
add env variables for custom certificate usage

### DIFF
--- a/dev/build/config.yml
+++ b/dev/build/config.yml
@@ -12,7 +12,13 @@ db:
 ssl:
   enabled: $(SSL_ACTIVE)
   port: 3443
-  provider: letsencrypt
+  provider: $(SSL_PROVIDER)
+  format: $(SSL_FORMAT)
+  key: $(SSL_PEM_KEY_FILEPATH)
+  cert: $(SSL_PEM_CERT_FILEPATH)
+  pfx: $(SSL_PFX_FILEPATH)
+  passphrase: $(SSL_PASSPHRASE)
+  dhparam: $(SSL_DHPARAM)
   domain: $(LETSENCRYPT_DOMAIN)
   subscriberEmail: $(LETSENCRYPT_EMAIL)
 logLevel: info

--- a/server/core/servers.js
+++ b/server/core/servers.js
@@ -57,7 +57,7 @@ module.exports = {
    * Start HTTPS Server
    */
   async startHTTPS () {
-    if (WIKI.config.ssl.provider === 'letsencrypt') {
+    if (WIKI.config.ssl.provider === 'letsencrypt' || WIKI.config.ssl.provider == null) {
       this.le = require('./letsencrypt')
       await this.le.init()
     }

--- a/server/core/servers.js
+++ b/server/core/servers.js
@@ -57,7 +57,7 @@ module.exports = {
    * Start HTTPS Server
    */
   async startHTTPS () {
-    if (WIKI.config.ssl.provider === 'letsencrypt' || WIKI.config.ssl.provider == null) {
+    if (WIKI.config.ssl.provider === 'letsencrypt') {
       this.le = require('./letsencrypt')
       await this.le.init()
     }

--- a/server/graph/resolvers/system.js
+++ b/server/graph/resolvers/system.js
@@ -239,7 +239,7 @@ module.exports = {
       try {
         if (!WIKI.config.ssl.enabled) {
           throw new WIKI.Error.SystemSSLDisabled()
-        } else if (WIKI.config.ssl.provider !== `letsencrypt`) {
+        } else if (WIKI.config.ssl.provider !== `letsencrypt` || WIKI.config.ssl.provider == null) {
           throw new WIKI.Error.SystemSSLRenewInvalidProvider()
         } else if (!WIKI.servers.le) {
           throw new WIKI.Error.SystemSSLLEUnavailable()

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -400,8 +400,8 @@ module.exports = class Page extends Model {
 
     // -> Check for source page access
     if (!WIKI.auth.checkAccess(opts.user, ['manage:pages'], {
-      locale: page.sourceLocale,
-      path: page.sourcePath
+      locale: page.localeCode,
+      path: page.path
     })) {
       throw new WIKI.Error.PageMoveForbidden()
     }


### PR DESCRIPTION
This would make it possible to use a custom certificate and therefore we gain more flexibility.
Before using a custom certificate, first it must be mounted with a volume. (e.g. with a volume entry  
like ` - /etc/ssl/wikijs:/path/to/folder/on/host:ro` in the Docker Compose file).
Unfortunately this is **not fully backwards compatible**, because the `SSL_PROVIDER` env variable has been added, so that all users currently using LE need to set this to `letsencrypt`. Maybe letsencrypt could be used as default so that old environment variables still work. Let me know if you have any better suggestions.
I would update the wiki accordingly if this PR is being considered.

**The following docker environment variables have been added:**
`SSL_PROVIDER` - This is either letsencrypt or custom
`SSL_FORMAT` - This is either pem or pfx
`SSL_PEM_KEY_FILEPATH` - File path to the key file in PEM on the container
`SSL_PEM_CERT_FILEPATH` - File path to the cert file in PEM on the container
`SSL_PFX_FILEPATH` - File path to the combined cert/key file in PFX on the container
`SSL_PASSPHRASE` - Passphrase for the Key files
`SSL_DHPARAM` - Diffie Hellman parameters

Please let me know what you think.