### PR TITLE
Content Search capabilities for default database search module

### DIFF
--- a/server/modules/search/db/definition.yml
+++ b/server/modules/search/db/definition.yml
@@ -5,4 +5,10 @@ author: requarks.io
 logo: https://static.requarks.io/logo/database.svg
 website: https://www.requarks.io/
 isAvailable: true
-props: {}
+props:
+  allowContentSearch:
+    type: Boolean
+    title: Allow content search
+    hint: 'Should Wiki.js search page contents as well? (Warning: Very database heavy)'
+    default: false
+    order: 1

--- a/server/modules/search/db/engine.js
+++ b/server/modules/search/db/engine.js
@@ -36,7 +36,7 @@ module.exports = {
             builderSub.orWhere('description', 'ILIKE', `%${q}%`)
             builderSub.orWhere('path', 'ILIKE', `%${q.toLowerCase()}%`)
             if (this.config.allowContentSearch) {
-              builderSub.orWhere('content', 'LIKE', `%${q}%`)
+              builderSub.orWhere('content', 'ILIKE', `%${q}%`)
             }
           } else {
             builderSub.where('title', 'LIKE', `%${q}%`)

--- a/server/modules/search/db/engine.js
+++ b/server/modules/search/db/engine.js
@@ -35,10 +35,16 @@ module.exports = {
             builderSub.where('title', 'ILIKE', `%${q}%`)
             builderSub.orWhere('description', 'ILIKE', `%${q}%`)
             builderSub.orWhere('path', 'ILIKE', `%${q.toLowerCase()}%`)
+            if (this.config.allowContentSearch) {
+              builderSub.orWhere('content', 'LIKE', `%${q}%`)
+            }
           } else {
             builderSub.where('title', 'LIKE', `%${q}%`)
             builderSub.orWhere('description', 'LIKE', `%${q}%`)
             builderSub.orWhere('path', 'LIKE', `%${q.toLowerCase()}%`)
+            if (this.config.allowContentSearch) {
+              builderSub.orWhere('content', 'LIKE', `%${q}%`)
+            }
           }
         })
       })


### PR DESCRIPTION
Adds an option to enable searching the contents of pages with the default database search plugin.

This feature can be enabled via "Administration" -> "Search Engine" -> "Database - Basic"
The option is disabled by default, to ensure initial behavior is the same.

There is a closed feature request for this here:
[https://wiki.js.org/feedback/p/search-for-content-and-title](https://wiki.js.org/feedback/p/search-for-content-and-title)

The behavior has been tested with postgresql and mssql database.



