### PR TITLE
Fix: Include locale in nav-sidebar "browse-mode" links

### DIFF
--- a/client/themes/default/components/nav-sidebar.vue
+++ b/client/themes/default/components/nav-sidebar.vue
@@ -40,7 +40,7 @@
           v-list-item-avatar(size='24')
             v-icon mdi-folder
           v-list-item-title {{ item.title }}
-        v-list-item(v-else, :href='`/` + item.path', :key='`childpage-` + item.id', :input-value='path === item.path')
+        v-list-item(v-else, :href='`/` + item.locale + `/` + item.path', :key='`childpage-` + item.id', :input-value='path === item.path')
           v-list-item-avatar(size='24')
             v-icon mdi-text-box
           v-list-item-title {{ item.title }}
@@ -132,6 +132,7 @@ export default {
                 isFolder
                 pageId
                 parent
+                locale
               }
             }
           }
@@ -159,6 +160,7 @@ export default {
                 isFolder
                 pageId
                 parent
+                locale
               }
             }
           }


### PR DESCRIPTION
Issue:
When multiple locales are enabled the sidebar page-browser only shows the currently selected locale. This is correct behavior. However when a page-link is opened it tries to open it with the default locale.

Fix:
Include the locale in the graphql-query and insert it into the link. This way if the query changes to include other locales in the future, these links will also work.

Another approach would be to use the current locale to open the links, but this would close the possibility to include other locales in the sidebar browser in the future.