### PR TITLE
Update engine.js

### DIFF
--- a/server/modules/search/elasticsearch/engine.js
+++ b/server/modules/search/elasticsearch/engine.js
@@ -92,8 +92,26 @@ module.exports = {
         index: this.config.indexName,
         body: {
           query: {
-            simple_query_string: {
-              query: q
+            bool: {
+              filter: [
+                {
+                  bool: {
+                    should: [
+                      {
+                        simple_query_string: {
+                          query: q
+                        }
+                      },
+                      {
+                        query_string: {
+                          query: "*" + q + "*"
+                        }
+                      }
+                    ],
+                    minimum_should_match: 1
+                  }
+                }
+              ]
             }
           },
           from: 0,


### PR DESCRIPTION
Improved full text search in elastic provider

Search bar now returns results on partial string match (eg. "ojec" will find documents with "project" without specyfying wildcard in search bar, what may be unclear for some users).