### PR TITLE
fix: login field placeholder

### DIFF
--- a/client/components/login.vue
+++ b/client/components/login.vue
@@ -30,7 +30,7 @@
                       hide-details
                       ref='iptEmail'
                       v-model='username'
-                      :placeholder='$t("auth:fields.emailUser")'
+                      :placeholder='(selectedStrategy.key === `ldap`) ? $t("auth:fields.user") : $t("auth:fields.email")'
                       )
                     v-text-field.mt-2(
                       solo


### PR DESCRIPTION
This fixes placeholder at login page related to #1742, #1532.

**Please add ``auth:fields.User`` -> ``Username`` to translation database.**
(I don't know how to do that....)