### PR TITLE
use fullname from keycloak profile info with username as fallback

### DIFF
--- a/server/modules/authentication/keycloak/authentication.js
+++ b/server/modules/authentication/keycloak/authentication.js
@@ -21,12 +21,16 @@ module.exports = {
         clientSecret: conf.clientSecret,
         callbackURL: conf.callbackURL
       }, async (accessToken, refreshToken, profile, cb) => {
+        let displayName = profile.username
+        if (_.isString(profile.fullName) && profile.fullName.length > 0) {
+          displayName = profile.fullName
+        }
         try {
           const user = await WIKI.models.users.processProfile({
             profile: {
               id: profile.keycloakId,
               email: profile.email,
-              name: profile.username,
+              name: displayName,
               picture: ''
             },
             providerKey: 'keycloak'


### PR DESCRIPTION
In the Keycloak authentication module, the username (given by Keycloak) was used as the display name in wiki.js.

I propose to use the fullName given by Keycloak, with the username as fallback value.