### PR TITLE
fix bullets position in rtl mode

### DIFF
--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -514,6 +514,7 @@
       width: 1.35rem;
 
       @at-root .is-rtl & {
+        right: -1.1rem;
         content: '\25C3';
       }
     }


### PR DESCRIPTION
Bullets (I don't know, list markers? whatever) are at the left edge in both RTL and LTR mode and this line fixes it.