### PR TITLE
Add Kroki renderer

### DIFF
--- a/server/modules/rendering/markdown-kroki/definition.yml
+++ b/server/modules/rendering/markdown-kroki/definition.yml
@@ -1,9 +1,9 @@
 key: markdownKroki
 title: Kroki
-description: Kroki Parser
+description: Kroki Diagrams Parser
 author: rlanyi (based on PlantUML renderer)
 icon: mdi-sitemap
-enabledDefault: true
+enabledDefault: false
 dependsOn: markdownCore
 props:
   server:

--- a/server/modules/rendering/markdown-kroki/definition.yml
+++ b/server/modules/rendering/markdown-kroki/definition.yml
@@ -1,0 +1,29 @@
+key: markdownKroki
+title: Kroki
+description: Kroki Parser
+author: rlanyi (based on PlantUML renderer)
+icon: mdi-sitemap
+enabledDefault: true
+dependsOn: markdownCore
+props:
+  server:
+    type: String
+    default: https://kroki.io
+    title: Kroki Server
+    hint: Kroki server used for image generation
+    order: 1
+    public: true
+  openMarker:
+    type: String
+    default: "```kroki"
+    title: Open Marker
+    hint: String to use as opening delimiter. Diagram type must be put in the next line in lowercase.
+    order: 2
+    public: true
+  closeMarker:
+    type: String
+    default: "```"
+    title: Close Marker
+    hint: String to use as closing delimiter
+    order: 3
+    public: true

--- a/server/modules/rendering/markdown-kroki/renderer.js
+++ b/server/modules/rendering/markdown-kroki/renderer.js
@@ -1,0 +1,143 @@
+const zlib = require('zlib')
+
+// ------------------------------------
+// Markdown - Kroki Preprocessor
+// ------------------------------------
+
+module.exports = {
+  init (mdinst, conf) {
+    mdinst.use((md, opts) => {
+      const openMarker = opts.openMarker || '```kroki'
+      const openChar = openMarker.charCodeAt(0)
+      const closeMarker = opts.closeMarker || '```'
+      const closeChar = closeMarker.charCodeAt(0)
+      const server = opts.server || 'https://kroki.io'
+
+      md.block.ruler.before('fence', 'kroki', (state, startLine, endLine, silent) => {
+        let nextLine
+        let markup
+        let params
+        let token
+        let i
+        let autoClosed = false
+        let start = state.bMarks[startLine] + state.tShift[startLine]
+        let max = state.eMarks[startLine]
+
+        // Check out the first character quickly,
+        // this should filter out most of non-uml blocks
+        //
+        if (openChar !== state.src.charCodeAt(start)) { return false }
+
+        // Check out the rest of the marker string
+        //
+        for (i = 0; i < openMarker.length; ++i) {
+          if (openMarker[i] !== state.src[start + i]) { return false }
+        }
+
+        markup = state.src.slice(start, start + i)
+        params = state.src.slice(start + i, max)
+
+        // Since start is found, we can report success here in validation mode
+        //
+        if (silent) { return true }
+
+        // Search for the end of the block
+        //
+        nextLine = startLine
+
+        for (;;) {
+          nextLine++
+          if (nextLine >= endLine) {
+            // unclosed block should be autoclosed by end of document.
+            // also block seems to be autoclosed by end of parent
+            break
+          }
+
+          start = state.bMarks[nextLine] + state.tShift[nextLine]
+          max = state.eMarks[nextLine]
+
+          if (start < max && state.sCount[nextLine] < state.blkIndent) {
+            // non-empty line with negative indent should stop the list:
+            // - ```
+            //  test
+            break
+          }
+
+          if (closeChar !== state.src.charCodeAt(start)) {
+            // didn't find the closing fence
+            continue
+          }
+
+          if (state.sCount[nextLine] > state.sCount[startLine]) {
+            // closing fence should not be indented with respect of opening fence
+            continue
+          }
+
+          var closeMarkerMatched = true
+          for (i = 0; i < closeMarker.length; ++i) {
+            if (closeMarker[i] !== state.src[start + i]) {
+              closeMarkerMatched = false
+              break
+            }
+          }
+
+          if (!closeMarkerMatched) {
+            continue
+          }
+
+          // make sure tail has spaces only
+          if (state.skipSpaces(start + i) < max) {
+            continue
+          }
+
+          // found!
+          autoClosed = true
+          break
+        }
+
+        let contents = state.src
+          .split('\n')
+          .slice(startLine + 1, nextLine)
+          .join('\n')
+
+        // We generate a token list for the alt property, to mimic what the image parser does.
+        let altToken = []
+        // Remove leading space if any.
+        let alt = params ? params.slice(1) : 'uml diagram'
+        state.md.inline.parse(
+          alt,
+          state.md,
+          state.env,
+          altToken
+        )
+
+        let firstlf = contents.indexOf('\n')
+        if (firstlf === -1) firstlf = undefined
+        let diagramType = contents.substring(0, firstlf)
+        contents = contents.substring(firstlf + 1)
+
+        let result = zlib.deflateSync(contents).toString('base64').replace(/\+/g, '-').replace(/\//g, '_')
+
+        token = state.push('kroki', 'img', 0)
+        // alt is constructed from children. No point in populating it here.
+        token.attrs = [ [ 'src', `${server}/${diagramType}/svg/${result}` ], [ 'alt', '' ], ['class', 'uml-diagram'] ]
+        token.block = true
+        token.children = altToken
+        token.info = params
+        token.map = [ startLine, nextLine ]
+        token.markup = markup
+
+        state.line = nextLine + (autoClosed ? 1 : 0)
+
+        return true
+      }, {
+        alt: [ 'paragraph', 'reference', 'blockquote', 'list' ]
+      })
+      md.renderer.rules.kroki = md.renderer.rules.image
+    }, {
+      openMarker: conf.openMarker,
+      closeMarker: conf.closeMarker,
+      server: conf.server
+    })
+  }
+}


### PR DESCRIPTION
This pull request adds support for https://kroki.io/ that can be used to generate diagrams from many different kinds of formats. It can be used as a replacement of the already existing PlantUML renderer and many other formats like GraphViz, Nomnoml, Mermaid and others.

The implementation is based on the PlantUML renderer. There's an important difference in the way it can be used: in the first line of the diagram definition the selected format must be entered.

Markdown Example 1:
````
```kroki
mermaid
graph TD
  A[ Anyone ] -->|Can help | B( Go to github.com/yuzutech/kroki )
  B --> C{ How to contribute? }
  C --> D[ Reporting bugs ]
  C --> E[ Sharing ideas ]
  C --> F[ Advocating ]
```
````

Markdown Example 2:
````
```kroki
plantuml
skinparam monochrome true
skinparam ranksep 20
skinparam dpi 150
skinparam arrowThickness 0.7
skinparam packageTitleAlignment left
skinparam usecaseBorderThickness 0.4
skinparam defaultFontSize 12
skinparam rectangleBorderThickness 1

rectangle "Main" {
  (main.view)
  (singleton)
}
rectangle "Base" {
  (base.component)
  (component)
  (model)
}
rectangle "<b>main.ts</b>" as main_ts

(component) ..> (base.component)
main_ts ==> (main.view)
(main.view) --> (component)
(main.view) ...> (singleton)
(singleton) ---> (model)
```
````