### PR TITLE
Development docker-compose.yml improvements

### DIFF
--- a/dev/containers/docker-compose.yml
+++ b/dev/containers/docker-compose.yml
@@ -4,6 +4,7 @@
 version: "3"
 services:
   db:
+    container_name: wiki-db
     image: postgres:9-alpine
     environment:
       POSTGRES_DB: wiki
@@ -13,26 +14,22 @@ services:
       driver: "none"
     volumes:
       - db-data:/var/lib/postgresql/data
-    networks:
-      - wikinet
     ports:
       - "15432:5432"
 
   adminer:
+    container_name: wiki-adminer
     image: adminer:latest
     logging:
       driver: "none"
-    networks:
-      - wikinet
     ports:
       - "3001:8080"
 
   # solr:
+  #   container_name: wiki-solr
   #   image: solr:7-alpine
   #   logging:
   #     driver: "none"
-  #   networks:
-  #     - wikinet
   #   ports:
   #     - "8983:8983"
   #   volumes:
@@ -43,21 +40,18 @@ services:
   #     - wiki
 
   wiki:
+    container_name: wiki-app
     build:
       context: ../..
       dockerfile: dev/containers/Dockerfile
     depends_on:
       - db
-    networks:
-      - wikinet
     ports:
       - "3000:3000"
     volumes:
       - ../..:/wiki
       - /wiki/node_modules
 
-networks:
-  wikinet:
 
 volumes:
   db-data:

--- a/dev/containers/docker-compose.yml
+++ b/dev/containers/docker-compose.yml
@@ -49,12 +49,9 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ../../client:/wiki/client
-      - ../../server:/wiki/server
-      - ../../dev:/wiki/dev
-      - ../../package.json:/wiki/package.json
-      - ../../yarn.lock:/wiki/yarn.lock
-      - ../../.babelrc:/wiki/.babelrc
+      - ../..:/wiki
+      - /wiki/node_modules
+      - /wiki/.git
 
 
 volumes:

--- a/dev/containers/docker-compose.yml
+++ b/dev/containers/docker-compose.yml
@@ -49,8 +49,12 @@ services:
     ports:
       - "3000:3000"
     volumes:
-      - ../..:/wiki
-      - /wiki/node_modules
+      - ../../client:/wiki/client
+      - ../../server:/wiki/server
+      - ../../dev:/wiki/dev
+      - ../../package.json:/wiki/package.json
+      - ../../yarn.lock:/wiki/yarn.lock
+      - ../../.babelrc:/wiki/.babelrc
 
 
 volumes:


### PR DESCRIPTION
- Adds `container_name` fields for cli convenience
- Removes the `wikinet` network -- Compose creates a network automatically
- Bind-mounts selectively
  - This fixes issues with the Git storage module in dev/docker mode. The issue is `/wiki/.git/` is bind mounted to the repo on the host, which interferes with the app's Git operations.

Let me know if you'd like me to rename commits (fix? feat?) or break it up into multiple PRs or anything like that.