### PR TITLE
fix: S3 Export all don't work #1604

### DIFF
--- a/server/models/storage.js
+++ b/server/models/storage.js
@@ -203,7 +203,7 @@ module.exports = class Storage extends Model {
     try {
       const target = _.find(this.targets, ['key', targetKey])
       if (target) {
-        if (_.has(target.fn, handler)) {
+        if (_.hasIn(target.fn, handler)) {
           await target.fn[handler]()
         } else {
           throw new Error('Invalid Handler for Storage Target')


### PR DESCRIPTION
fix: #1604

exportAll action on s3 doesn't work.
The reason being that s3 handler is a class instance and not a plain object, thus when checking if the handler has the exportAll method, fails.
The fix is to use lodash `hasIn` which checks if a propery exists directly or inherited on an object.

I confirmed the fix locally ofcourse