### PR TITLE
Make the links to subtitles work with special characters

### DIFF
--- a/client/themes/default/components/page.vue
+++ b/client/themes/default/components/page.vue
@@ -530,12 +530,13 @@ export default {
       }
     }
 
+    // -> Handle anchor links within the page contents
     this.$nextTick(() => {
       this.$refs.container.querySelectorAll(`a[href^="#"], a[href^="${window.location.href.replace(window.location.hash, '')}#"]`).forEach(el => {
         el.onclick = ev => {
           ev.preventDefault()
           ev.stopPropagation()
-          this.$vuetify.goTo(ev.target.hash, this.scrollOpts)
+          this.$vuetify.goTo(decodeURIComponent(ev.target.hash), this.scrollOpts)
         }
       })
     })


### PR DESCRIPTION
This issue is related to #1006 . The $vuetify.goTo() function expects a UTF-8 ev.target.hash . However, the markdown CRM URIencodes the ev.target.hash (this is great for browser compatibility, not so much for Vuetify)

Adding decodeURIComponent() to ev.target.hash fixes compatibility with Vuetify.

This fixes GitHub issue #1873

