### PR TITLE
Fix #1958 404 on android-icon-192x192

### DIFF
--- a/dev/helm/Chart.yaml
+++ b/dev/helm/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - reference
   - editor
 home: https://wiki.js.org
-icon: https://github.com/Requarks/wiki/raw/master/client/static/favicons/android-icon-192x192.png
+icon: https://github.com/Requarks/wiki/raw/master/client/static/favicons/android-chrome-192x192.png
 sources:
   - https://github.com/Requarks/wiki
 maintainers:

--- a/dev/templates/master.pug
+++ b/dev/templates/master.pug
@@ -21,7 +21,7 @@ html(lang=siteConfig.lang)
 
     //- Favicon
     link(rel='apple-touch-icon', sizes='180x180', href='/_assets/favicons/apple-touch-icon.png')
-    link(rel='icon', type='image/png', sizes='192x192', href='/_assets/favicons/android-icon-192x192.png')
+    link(rel='icon', type='image/png', sizes='192x192', href='/_assets/favicons/android-chrome-192x192.png')
     link(rel='icon', type='image/png', sizes='32x32', href='/_assets/favicons/favicon-32x32.png')
     link(rel='icon', type='image/png', sizes='16x16', href='/_assets/favicons/favicon-16x16.png')
     link(rel='mask-icon', href='/_assets/favicons/safari-pinned-tab.svg', color='#1976d2')

--- a/dev/templates/setup.pug
+++ b/dev/templates/setup.pug
@@ -11,7 +11,7 @@ html
 
     //- Favicon
     link(rel='apple-touch-icon', sizes='180x180', href='/apple-touch-icon.png')
-    link(rel='icon', type='image/png', sizes='192x192', href='/favicons/android-icon-192x192.png')
+    link(rel='icon', type='image/png', sizes='192x192', href='/favicons/android-chrome-192x192.png')
     link(rel='icon', type='image/png', sizes='32x32', href='/favicons/favicon-32x32.png')
     link(rel='icon', type='image/png', sizes='16x16', href='/favicons/favicon-16x16.png')
     link(rel='mask-icon', href='/favicons/safari-pinned-tab.svg', color='#1976d2')


### PR DESCRIPTION
Fix https://github.com/Requarks/wiki/issues/1958 "404 on android-icon-192x192" :
the existing filename is in fact android-chrome-192x192.png instead of android-icon-192x192.png