### PR TITLE
Fix #1964 404 on apple-touch-icon

### DIFF
--- a/dev/templates/legacy.pug
+++ b/dev/templates/legacy.pug
@@ -20,7 +20,7 @@ html
     meta(property='og:site_name', content=config.title)
 
     //- Favicon
-    link(rel='apple-touch-icon', sizes='180x180', href='/apple-touch-icon.png')
+    link(rel='apple-touch-icon', sizes='180x180', href='/favicons/apple-touch-icon.png')
     link(rel='icon', type='image/png', sizes='192x192', href='/favicons/android-icon-192x192.png')
     link(rel='icon', type='image/png', sizes='32x32', href='/favicons/favicon-32x32.png')
     link(rel='icon', type='image/png', sizes='16x16', href='/favicons/favicon-16x16.png')

--- a/dev/templates/setup.pug
+++ b/dev/templates/setup.pug
@@ -10,7 +10,7 @@ html
     title Wiki.js Setup
 
     //- Favicon
-    link(rel='apple-touch-icon', sizes='180x180', href='/apple-touch-icon.png')
+    link(rel='apple-touch-icon', sizes='180x180', href='/favicons/apple-touch-icon.png')
     link(rel='icon', type='image/png', sizes='192x192', href='/favicons/android-chrome-192x192.png')
     link(rel='icon', type='image/png', sizes='32x32', href='/favicons/favicon-32x32.png')
     link(rel='icon', type='image/png', sizes='16x16', href='/favicons/favicon-16x16.png')


### PR DESCRIPTION
Fix https://github.com/Requarks/wiki/issues/1964 "404 on apple-touch-icon" : 
the existing filename apple-touch-icon.png is in fact in /favicons/ instead of /