### PR TITLE
fix: sidebar base64 decode

### DIFF
--- a/client/themes/default/components/page.vue
+++ b/client/themes/default/components/page.vue
@@ -473,10 +473,10 @@ export default {
       }
     },
     sidebarDecoded () {
-      return JSON.parse(atob(this.sidebar))
+      return JSON.parse(Buffer.from(this.sidebar, 'base64').toString())
     },
     tocDecoded () {
-      return JSON.parse(atob(this.toc))
+      return JSON.parse(Buffer.from(this.toc, 'base64').toString())
     }
   },
   created() {


### PR DESCRIPTION
This fixes garbled sidebar text. (fix #1971)
``atob()`` function has a Unicode Problem.

> The btoa() function takes a JavaScript string as a parameter. In JavaScript strings are represented using the UTF-16 character encoding: in this encoding, strings are represented as a sequence of 16-bit (2 byte) units. Every ASCII character fits into the first byte of one of these units, but **many other characters don't**.     -- from [MDN web docs](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/btoa)

**ScreenShot**
![compare](https://user-images.githubusercontent.com/18533151/83399040-79b2ad00-a43b-11ea-9158-105d8b001eef.png)
