### PR TITLE
Fix: Respect image floating from visual editor

### DIFF
--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -718,6 +718,14 @@
     }
   }
 
+  figure.image-style-align-right {
+    float: right;
+  }
+
+  figure.image-style-align-left {
+    float: left;
+  }
+
   // ---------------------------------
   // DETAILS
   // ---------------------------------


### PR DESCRIPTION
Implements the missing `figure.image-style-align-right` and `figure.image-style-align-left` css. Closes #1413.