### PR TITLE
Change reconnectLink behavior for page move

### DIFF
--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -482,13 +482,20 @@ module.exports = class Page extends Model {
       })
     }
 
-    // -> Reconnect Links
+    // -> Reconnect Links : Changing old links to the new path
     await WIKI.models.pages.reconnectLinks({
       sourceLocale: page.localeCode,
       sourcePath: page.path,
       locale: opts.destinationLocale,
       path: opts.destinationPath,
       mode: 'move'
+    })
+   
+    // -> Reconnect Links : Validate invalid links to the new path
+    await WIKI.models.pages.reconnectLinks({
+      locale: opts.destinationLocale,
+      path: opts.destinationPath,
+      mode: 'create'
     })
   }
 
@@ -578,7 +585,7 @@ module.exports = class Page extends Model {
         break
       case 'move':
         const prevPageHref = `/${opts.sourceLocale}/${opts.sourcePath}`
-        replaceArgs.from = `<a href="${prevPageHref}" class="is-internal-link is-invalid-page">`
+        replaceArgs.from = `<a href="${prevPageHref}" class="is-internal-link is-valid-page">`
         replaceArgs.to = `<a href="${pageHref}" class="is-internal-link is-valid-page">`
         break
       case 'delete':


### PR DESCRIPTION
Move behavior of `reconnectLinks` was replacing
```
<a href="old-path" class="invalid">
```
with 
```
<a href="new-path" class="valid">
```
but we know that before the move we have valid links like
```
<a href="old-path" class="valid">
```

Another necessary change was that if a page is moved from `old-path` to `new-path` we have to do something more than this. We may have invalid links to the new path, like
```
<a href="new-path" class="invalid">
```
which they shall be valid now.
And this is the same process that is done in page creation.

This fixes #1990 

