### PR TITLE
fix: secure html module removes target attribute from links #2011

### DIFF
--- a/server/modules/rendering/html-security/renderer.js
+++ b/server/modules/rendering/html-security/renderer.js
@@ -7,7 +7,7 @@ module.exports = {
       const window = new JSDOM('').window
       const DOMPurify = createDOMPurify(window)
 
-      const allowedAttrs = ['v-pre', 'v-slot:tabs', 'v-slot:content']
+      const allowedAttrs = ['v-pre', 'v-slot:tabs', 'v-slot:content', 'target']
       const allowedTags = ['tabset', 'template']
 
       if (config.allowIFrames) {


### PR DESCRIPTION
Fix: #2011

Reproduced the bug on master, and verified the fix