### PR TITLE
docs: Added demo possibility

### DIFF
--- a/.runme/config.yaml
+++ b/.runme/config.yaml
@@ -1,0 +1,21 @@
+version: '1.0'
+publish: wiki
+services:
+  wiki:
+    image: requarks/wiki:latest
+    environment:
+      DB_TYPE: mysql
+      DB_PORT: 3306
+      DB_HOST: mysql
+      DB_USER: root
+      DB_PASS: demo
+      DB_NAME: wiki
+    ports:
+    - container: 3000
+      public: 80
+
+  mysql:
+    image: bitnami/mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: demo
+      MYSQL_DATABASE: wiki

--- a/.runme/config.yaml
+++ b/.runme/config.yaml
@@ -1,4 +1,4 @@
-version: '1.0'
+version: 1.0
 publish: wiki
 services:
   wiki:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ You can also use Docker Compose ([see example](https://github.com/Requarks/wiki/
 
 <div align="center">
 
-Check out our [documentation site](https://docs.requarks.io), it's running Wiki.js!
+Click on [![Runme](https://runme.io/static/button.svg)](https://runme.io/run?app_id=2c611fb1-84e5-4ce8-8efc-3333111e495a) or
+
+check out our [documentation site](https://docs.requarks.io), it's running Wiki.js!
 
 </div>
 


### PR DESCRIPTION
This PR adds Runme button-label [![Runme](https://runme.io/static/button.svg)](https://runme.io/run?app_id=5681a667-6687-40e1-b6be-f543e6803ef0) (forked on cloned repo) to run the project from latest commit with one click.

**How it works:**
1. Runme clones the repository and builds a docker image for latest commit;
2. deploys docker image to k8s cluster;
3. creates domain with SSL certificate;
4. shows web application;
5. destroys app instance after 10 minutes.

You can find detailed information on how this works [here](https://runme.io/how-it-works). The small demo you can find [here](https://www.youtube.com/channel/UCEysV237wo321JatUTC6Rlg).

**Why we suggest this?**
- Runme is perfect solution to demonstrate current state of code/repository, anybody can just click the button and see the state;
- Runme totally free, we love open source projects and want to support them;
- Runme has only one limit: you can run one commit no more than once every 5 minutes;

Result will looks like : 
![image](https://user-images.githubusercontent.com/5084181/84000044-389f2900-a964-11ea-9ca6-80e1791eec85.png)

