### PR TITLE
fix: sidebar is empty when the jwt token is expired #2036

### DIFF
--- a/server/core/auth.js
+++ b/server/core/auth.js
@@ -118,6 +118,7 @@ module.exports = {
           const newToken = await WIKI.models.users.refreshToken(jwtPayload.id)
           user = newToken.user
           user.permissions = user.getGlobalPermissions()
+          user.groups = user.getGroups()
           req.user = user
 
           // Try headers, otherwise cookies for response


### PR DESCRIPTION
fix: #2036 
More details in the ticket

Summary:
The groups property of the user after token refresh was not normalized using user.getGroups() so the [access filter](https://github.com/Requarks/wiki/blob/1ca29dd66af7892c07970e53661d40d9b2c3d1d1/server/models/navigation.js#L62) on the sidebar always returned empty array.