### PR TITLE
change language in edit, history and source pages

### DIFF
--- a/server/controllers/common.js
+++ b/server/controllers/common.js
@@ -44,6 +44,8 @@ router.get(['/a', '/a/*'], (req, res, next) => {
 router.get(['/d', '/d/*'], async (req, res, next) => {
   const pageArgs = pageHelper.parsePath(req.path, { stripExt: true })
 
+  req.i18n.changeLanguage(pageArgs.locale)
+  
   const versionId = (req.query.v) ? _.toSafeInteger(req.query.v) : 0
 
   const page = await WIKI.models.pages.getPageFromDb({
@@ -91,6 +93,8 @@ router.get(['/e', '/e/*'], async (req, res, next) => {
     return res.redirect(`/e/${pageArgs.locale}/${pageArgs.path}`)
   }
 
+  req.i18n.changeLanguage(pageArgs.locale)
+  
   // -> Set Editor Lang
   _.set(res, 'locals.siteConfig.lang', pageArgs.locale)
   _.set(res, 'locals.siteConfig.rtl', req.i18n.dir() === 'rtl')
@@ -208,6 +212,8 @@ router.get(['/h', '/h/*'], async (req, res, next) => {
   if (WIKI.config.lang.namespacing && !pageArgs.explicitLocale) {
     return res.redirect(`/h/${pageArgs.locale}/${pageArgs.path}`)
   }
+  
+  req.i18n.changeLanguage(pageArgs.locale)
 
   _.set(res, 'locals.siteConfig.lang', pageArgs.locale)
   _.set(res, 'locals.siteConfig.rtl', req.i18n.dir() === 'rtl')


### PR DESCRIPTION
I guess this change will fix #1578, #2004 and maybe more.

How did I come up with this fix?
1. We had a line

https://github.com/Requarks/wiki/blob/a0618ee4f6b47db53163263e9c57528063508f8e/client/components/editor/editor-markdown.vue#L661

2. At the browser console **for edit pages**, the `siteConfig` was equal to 
```
siteConfig
Object { title: ..., lang: "fa", rtl: false, ... }
```
and it `rtl: true` for **wiki pages**.

3. At the server-side, we use following logic to set locale and rtl. (for all both edit and wiki pages)
https://github.com/Requarks/wiki/blob/122235504654881b6dd78807ded1387f4ea17c16/server/controllers/common.js#L394-L395 
we see that `rtl` parameter uses the localization engine which is i18next.

4. The point is that there was 
https://github.com/Requarks/wiki/blob/122235504654881b6dd78807ded1387f4ea17c16/server/controllers/common.js#L366
**only for wiki pages**, this line would change the language for i18next, therefore, `rtl` value became valid.

5. therefore adding that line to other functions will solve localization problems there.

6. But maybe it's not the best practice. there is a LanguageDetector middleware inside the i18neMW that can detect the language from the path. if the default detector cannot work we can implement our custom LanguageDetector. (more on [here](https://github.com/i18next/i18next-express-middleware#language-detection))

Bonus fact: [i18neMW](https://github.com/i18next/i18next-express-middleware) that we are using is deprecated and its successor is [i18nhMW](https://github.com/i18next/i18next-http-middleware).