### PR TITLE
Support for client side debugging in VSCode

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,11 @@
 {
   "comments": true,
+  "env": {
+    "development": {
+      "sourceMaps": true,
+      "retainLines": true
+    }
+  },
   "plugins": [
     "lodash",
     "graphql-tag",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "dbaeumer.vscode-eslint",
     "christian-kohler.path-intellisense",
     "mrmlnc.vscode-puglint",
-    "octref.vetur"
+    "octref.vetur",
+    "firefox-devtools.vscode-firefox-debug"
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
             "type": "node",
             "request": "launch",
             "name": "Launch Program",
-            "program": "${workspaceRoot}\\server.js"
+            "program": "${workspaceRoot}\\server\\index.js"
         },
         {
             "type": "node",
@@ -36,7 +36,7 @@
             "type": "firefox",
             "request": "launch",
             "url": "http://localhost:3000/",
-            "webRoot": "${workspaceFolder}/wwwroot",
+            "webRoot": "${workspaceFolder}",
             "pathMappings": [
                 {
                     "url": "webpack:///client",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -36,11 +36,11 @@
             "type": "firefox",
             "request": "launch",
             "url": "http://localhost:3000/",
-            "webRoot": "${workspaceFolder}",
+            "webRoot": "${workspaceRoot}",
             "pathMappings": [
                 {
                     "url": "webpack:///client",
-                    "path": "${workspaceFolder}/client"
+                    "path": "${workspaceRoot}/client"
                 }
             ]
         },

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,14 +3,13 @@
     // Hover to view descriptions of existing attributes.
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
+    "compounds": [
+        {
+            "name": "Server / Client Debug",
+            "configurations": ["Launch Program", "Launch Firefox Client Debug"]
+        }
+    ],
     "configurations": [
-    {
-      "type": "node",
-      "request": "attach",
-      "name": "Attach (Inspector Protocol)",
-      "port": 9229,
-      "protocol": "inspector"
-    },
         {
             "type": "node",
             "request": "launch",
@@ -23,6 +22,27 @@
             "name": "Attach to Port",
             "address": "localhost",
             "port": 9222
-        }
+        },
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach (Inspector Protocol)",
+            "port": 9229,
+            "protocol": "inspector"
+        },
+
+        {
+            "name": "Launch Firefox Client Debug",
+            "type": "firefox",
+            "request": "launch",
+            "url": "http://localhost:3000/",
+            "webRoot": "${workspaceFolder}/wwwroot",
+            "pathMappings": [
+                {
+                    "url": "webpack:///client",
+                    "path": "${workspaceFolder}/client"
+                }
+            ]
+        },
     ]
 }

--- a/dev/webpack/webpack.dev.js
+++ b/dev/webpack/webpack.dev.js
@@ -23,6 +23,7 @@ fs.emptyDirSync(path.join(process.cwd(), 'assets'))
 
 module.exports = {
   mode: 'development',
+  devtool: 'source-map',
   entry: {
     app: ['./client/index-app.js', 'webpack-hot-middleware/client'],
     legacy: ['./client/index-legacy.js', 'webpack-hot-middleware/client'],

--- a/wikijs.code-workspace
+++ b/wikijs.code-workspace
@@ -1,8 +1,0 @@
-{
-  "folders": [
-    {
-      "name": "wikijs",
-      "path": "."
-    },
-  ]
-}

--- a/wikijs.code-workspace
+++ b/wikijs.code-workspace
@@ -1,0 +1,8 @@
+{
+  "folders": [
+    {
+      "name": "wikijs",
+      "path": "."
+    },
+  ]
+}


### PR DESCRIPTION
Hi,
I've added some changes to allow for debugging the client side of the code via VSCode
so you should be able to add breakpoints to files within the client directory in vscode and have them hit when the browser reaches that point

I was looking into this as I'm interested in writing my own theme

  * code-workspace file - just an easy way / shortcut of double clicking to open up in vscode, without doing File Open folder.
  * changes to .babelrc / dev/webpack/webpack.dev.js - enable source maps to allow the browser to map back to the code in vscode
  * changes to extensions.json / launch.json - allow for launching of firefox / server or both

I did try to get this working with the chrome debugger for vscode initially but I think it has some compatibility issues with the generated source maps. It breakpoints on regular .js files, but then gets confused which line to map to for the code inside .vue files

At a guess it might be babel I'm not sure.
I have other projects with vue files that don't have this problem but they don't use babel so that's just a guess.
I was able to get around it by using the firefox debugger instead which seems to handle it without any problems

The only downside is that you have to refresh the page after launching to trigger any immediate breakpoints, since it takes a few seconds for firefox to recognise the set breakpoints.
