### PR TITLE
bug: playing a video from assets is super slow #2074

### DIFF
--- a/server/models/assets.js
+++ b/server/models/assets.js
@@ -6,6 +6,7 @@ const path = require('path')
 const fs = require('fs-extra')
 const _ = require('lodash')
 const assetHelper = require('../helpers/asset')
+const Promise = require('bluebird')
 
 /**
  * Users model
@@ -150,32 +151,53 @@ module.exports = class Asset extends Model {
   }
 
   static async getAsset(assetPath, res) {
-    let assetExists = await WIKI.models.assets.getAssetFromCache(assetPath, res)
-    if (!assetExists) {
-      await WIKI.models.assets.getAssetFromDb(assetPath, res)
+    try {
+      const fileHash = assetHelper.generateHash(assetPath)
+      const cachePath = path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `cache/${fileHash}.dat`)
+      if (await WIKI.models.assets.getAssetFromCache(assetPath, cachePath, res)) {
+        return
+      }
+      if (await WIKI.models.assets.getAssetFromStorage(assetPath, res)) {
+        return
+      }
+      await WIKI.models.assets.getAssetFromDb(assetPath, fileHash, cachePath, res)
+    } catch (err) {
+      if (err.code === `ECONNABORTED` || err.code === `EPIPE`) {
+        return
+      }
+      WIKI.logger.error(err)
+      res.sendStatus(500)
     }
   }
 
-  static async getAssetFromCache(assetPath, res) {
-    const fileHash = assetHelper.generateHash(assetPath)
-    const cachePath = path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `cache/${fileHash}.dat`)
-
-    return new Promise((resolve, reject) => {
-      res.type(path.extname(assetPath))
-      res.sendFile(cachePath, { dotfiles: 'deny' }, err => {
-        if (err) {
-          resolve(false)
-        } else {
-          resolve(true)
-        }
-      })
-    })
+  static async getAssetFromCache(assetPath, cachePath, res) {
+    try {
+      await fs.access(cachePath, fs.constants.R_OK)
+    } catch (err) {
+      return false
+    }
+    const sendFile = Promise.promisify(res.sendFile, {context: res})
+    res.type(path.extname(assetPath))
+    await sendFile(cachePath, { dotfiles: 'deny' })
+    return true
   }
 
-  static async getAssetFromDb(assetPath, res) {
-    const fileHash = assetHelper.generateHash(assetPath)
-    const cachePath = path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `cache/${fileHash}.dat`)
+  static async getAssetFromStorage(assetPath, res) {
+    const localLocations = await WIKI.models.storage.getLocalLocations({
+      asset: {
+        path: assetPath,
+      }
+    })
+    for (let location of _.filter(localLocations, location => Boolean(location.path))) {
+      const assetExists = await WIKI.models.assets.getAssetFromCache(assetPath, location.path, res)
+      if (assetExists) {
+        return true
+      }
+    }
+    return false
+  }
 
+  static async getAssetFromDb(assetPath, fileHash, cachePath, res) {
     const asset = await WIKI.models.assets.query().where('hash', fileHash).first()
     if (asset) {
       const assetData = await WIKI.models.knex('assetData').where('id', asset.id).first()

--- a/server/models/storage.js
+++ b/server/models/storage.js
@@ -199,6 +199,23 @@ module.exports = class Storage extends Model {
     }
   }
 
+  static async getLocalLocations({ asset }) {
+    const locations = []
+    const promises = this.targets.map(async (target) => {
+      try {
+        const path = await target.fn.getLocalLocation(asset)
+        locations.push({
+          path,
+          key: target.key
+        })
+      } catch (err) {
+        WIKI.logger.warn(err)
+      }
+    })
+    await Promise.all(promises)
+    return locations
+  }
+
   static async executeAction(targetKey, handler) {
     try {
       const target = _.find(this.targets, ['key', targetKey])

--- a/server/modules/storage/azure/storage.js
+++ b/server/modules/storage/azure/storage.js
@@ -115,6 +115,9 @@ module.exports = {
       deleteSnapshots: 'include'
     })
   },
+  async getLocalLocation () {
+
+  },
   /**
    * HANDLERS
    */

--- a/server/modules/storage/box/storage.js
+++ b/server/modules/storage/box/storage.js
@@ -19,5 +19,8 @@ module.exports = {
   },
   async renamed() {
 
+  },
+  async getLocalLocation () {
+
   }
 }

--- a/server/modules/storage/disk/storage.js
+++ b/server/modules/storage/disk/storage.js
@@ -116,7 +116,9 @@ module.exports = {
     WIKI.logger.info(`(STORAGE/DISK) Renaming file from ${asset.path} to ${asset.destinationPath}...`)
     await fs.move(path.join(this.config.path, asset.path), path.join(this.config.path, asset.destinationPath), { overwrite: true })
   },
-
+  async getLocalLocation (asset) {
+    return path.join(this.config.path, asset.path)
+  },
   /**
    * HANDLERS
    */

--- a/server/modules/storage/dropbox/storage.js
+++ b/server/modules/storage/dropbox/storage.js
@@ -19,5 +19,8 @@ module.exports = {
   },
   async renamed() {
 
+  },
+  async getLocalLocation () {
+
   }
 }

--- a/server/modules/storage/gdrive/storage.js
+++ b/server/modules/storage/gdrive/storage.js
@@ -19,5 +19,8 @@ module.exports = {
   },
   async renamed() {
 
+  },
+  async getLocalLocation () {
+
   }
 }

--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -363,6 +363,9 @@ module.exports = {
       '--author': `"${asset.moveAuthorName} <${asset.moveAuthorEmail}>"`
     })
   },
+  async getLocalLocation (asset) {
+    return path.join(this.repoPath, asset.path)
+  },
   /**
    * HANDLERS
    */

--- a/server/modules/storage/onedrive/storage.js
+++ b/server/modules/storage/onedrive/storage.js
@@ -19,5 +19,8 @@ module.exports = {
   },
   async renamed() {
 
+  },
+  async getLocalLocation () {
+
   }
 }

--- a/server/modules/storage/s3/common.js
+++ b/server/modules/storage/s3/common.js
@@ -120,6 +120,9 @@ module.exports = class S3CompatibleStorage {
     await this.s3.copyObject({ CopySource: asset.path, Key: asset.destinationPath }).promise()
     await this.s3.deleteObject({ Key: asset.path }).promise()
   }
+  async getLocalLocation () {
+
+  }
   /**
    * HANDLERS
    */

--- a/server/modules/storage/sftp/storage.js
+++ b/server/modules/storage/sftp/storage.js
@@ -104,6 +104,9 @@ module.exports = {
     await this.ensureDirectory(asset.destinationPath)
     await this.sftp.rename(path.posix.join(this.config.basePath, asset.path), path.posix.join(this.config.basePath, asset.destinationPath))
   },
+  async getLocalLocation () {
+
+  },
   /**
    * HANDLERS
    */


### PR DESCRIPTION
fix: #2074

Backstory - I uploaded a large 100mb mp4 video as an asset (using postgres as the db) and added an html5 video element to play it in a page. As soon as the page was trying to load, my wiki server just stopped responding for a good few minutes. Cpu was spiking at 100%.
After a lot of investigation, I came to realize that the issue occurs due to a performance bug in the `node-postgress` library. I already fixed [the bug](https://github.com/brianc/node-postgres/pull/2241) ~~and waiting for CR on it.~~ and it was released and it is already being used in the master branch.

This PR fixes a performance issue while handling videos:
When a request is aborted (due to change of playing position for example) the browser cancels the request, but the error handling in the code ignored it and tried to send the file again from DB which wastes time and causes more issue and the response is already closed.

In addition, I thought about an optimization - instead of fetching assets from db and caching them, the assets might already be cached on the local disk on one of the storage modules (git or disk), so why not use them?
The reason I came up with the optimization is that even after my fix to node-postgres it still takes 40 whole seconds to retrieve the 100mb video file from the DB and it is simply a bad user experience...