### PR TITLE
fix: page schema validation

### DIFF
--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -856,8 +856,8 @@ module.exports = class Page extends Model {
       creatorName: page.creatorName,
       description: page.description,
       extra: {
-        css: page.extra ? page.extra.css : '',
-        js: page.extra ? page.extra.js : ''
+        css: _.get(page, 'extra.css', ''),
+        js: _.get(page, 'extra.js', '')
       },
       isPrivate: page.isPrivate === 1 || page.isPrivate === true,
       isPublished: page.isPublished === 1 || page.isPublished === true,


### PR DESCRIPTION
I have a local development instance using sqlite. After pulling the latest code, I receive errors while trying to load the website.

The reason is validation error for the page schema. 

This PR fixes the issue (current implementation sets js and css to be undefined in case extra is an empty object)