### PR TITLE
fix: tags are not filtered by access #1884

### DIFF
--- a/server/graph/resolvers/page.js
+++ b/server/graph/resolvers/page.js
@@ -181,7 +181,8 @@ module.exports = {
           path: r.path,
           locale: r.locale
         })
-      }).flatMap(r => r.tags)
+      })
+        .flatMap(r => r.tags)
       return _.orderBy(_.uniqBy(allTags, 'id'), ['tag'], ['asc'])
     },
     /**
@@ -211,7 +212,8 @@ module.exports = {
           path: r.path,
           locale: r.locale
         })
-      }).flatMap(r => r.tags)
+      })
+        .flatMap(r => r.tags)
         .map(t => t.tag)
       return _.uniq(allTags).slice(0, 5)
     },

--- a/server/graph/resolvers/page.js
+++ b/server/graph/resolvers/page.js
@@ -171,26 +171,49 @@ module.exports = {
      * FETCH TAGS
      */
     async tags (obj, args, context, info) {
-      return WIKI.models.tags.query().orderBy('tag', 'asc')
+      const pages = await WIKI.models.pages.query().column([
+        'path',
+        { locale: 'localeCode' },
+      ])
+        .withGraphJoined('tags')
+      const allTags = _.filter(pages, r => {
+        return WIKI.auth.checkAccess(context.req.user, ['read:pages'], {
+          path: r.path,
+          locale: r.locale
+        })
+      }).flatMap(r => r.tags)
+      return _.orderBy(_.uniqBy(allTags, 'id'), ['tag'], ['asc'])
     },
     /**
      * SEARCH TAGS
      */
     async searchTags (obj, args, context, info) {
       const query = _.trim(args.query)
-      const results = await WIKI.models.tags.query()
-        .column('tag')
-        .where(builder => {
-          builder.andWhere(builderSub => {
+      const pages = await WIKI.models.pages.query().column([
+        'path',
+        { locale: 'localeCode' },
+      ])
+        .withGraphJoined('tags')
+        .modifyGraph('tags', builder => {
+          builder.select('tag')
+        })
+        .modify(queryBuilder => {
+          queryBuilder.andWhere(builderSub => {
             if (WIKI.config.db.type === 'postgres') {
-              builderSub.where('tag', 'ILIKE', `%${query}%`)
+              builderSub.where('tags.tag', 'ILIKE', `%${query}%`)
             } else {
-              builderSub.where('tag', 'LIKE', `%${query}%`)
+              builderSub.where('tags.tag', 'LIKE', `%${query}%`)
             }
           })
         })
-        .limit(5)
-      return results.map(r => r.tag)
+      const allTags = _.filter(pages, r => {
+        return WIKI.auth.checkAccess(context.req.user, ['read:pages'], {
+          path: r.path,
+          locale: r.locale
+        })
+      }).flatMap(r => r.tags)
+        .map(t => t.tag)
+      return _.uniq(allTags).slice(0, 5)
     },
     /**
      * FETCH PAGE TREE


### PR DESCRIPTION
fixes: #1884

Tags retrieval and search will always return all tags, regardless of what the user is allowed to see.
This PR fixes this issue.

### Caveats
- Tags that are not associated to any pages will never be returned! Not sure what is the right course of action here - should we always return those orphan tags? If we do than that might impose a security leak...
- This makes the queries a bit slower as we need to get the pages first so we can filter by access
- We can't impose the search result size limit in the query itself as we can receive many duplicates, so we have to get all the tags and then extract the first 5 results. I thought about reversing the query to get the tags and join with the pages, but then if we ask for top 5 we might remove some of them due to access restrictions and we will loose other good results.
- There is no specific order to the tags when making a search, maybe we can improve it somehow
