### PR TITLE
Add authConfig endpoint and fetch on admin auth page

### DIFF
--- a/client/graph/admin/auth/auth-query-config.gql
+++ b/client/graph/admin/auth/auth-query-config.gql
@@ -1,0 +1,9 @@
+query {
+  authentication {
+    authConfig {
+      audience
+      tokenExpiration
+      tokenRenewal
+    }
+  }
+}

--- a/server/graph/resolvers/authentication.js
+++ b/server/graph/resolvers/authentication.js
@@ -59,6 +59,12 @@ module.exports = {
         }
       })
       return strategies
+    },
+    /**
+     * Fetch auth config
+     */
+    authConfig () {
+      return WIKI.config.auth
     }
   },
   AuthenticationMutation: {

--- a/server/graph/schemas/authentication.graphql
+++ b/server/graph/schemas/authentication.graphql
@@ -23,7 +23,7 @@ type AuthenticationQuery {
     isEnabled: Boolean
   ): [AuthenticationStrategy]
 
-  authConfig: AuthenticationConfig
+  authConfig: AuthenticationConfig @auth(requires: ["manage:system"])
 }
 
 # -----------------------------------------------

--- a/server/graph/schemas/authentication.graphql
+++ b/server/graph/schemas/authentication.graphql
@@ -22,6 +22,8 @@ type AuthenticationQuery {
   strategies(
     isEnabled: Boolean
   ): [AuthenticationStrategy]
+
+  authConfig: AuthenticationConfig
 }
 
 # -----------------------------------------------
@@ -139,4 +141,10 @@ type AuthenticationApiKey {
 type AuthenticationCreateApiKeyResponse {
   responseResult: ResponseStatus
   key: String
+}
+
+type AuthenticationConfig {
+  audience: String
+  tokenExpiration: String
+  tokenRenewal: String
 }


### PR DESCRIPTION
Fixes #1951 

As I mention in [my comment](https://github.com/Requarks/wiki/issues/1951#issuecomment-649837557), currently (despite being able to save them) the auth config values (i.e. the "Global Advanced Settings" on the auth admin page) aren't actually _fetched_ on the page. This means that when you revisit the page it would display the default values again, and if you clicked Apply it would overwrite your changes with those defaults.

This adds a new GraphQL endpoint to fetch this auth config, and then modifies the auth admin page to use the new endpoint to display the correct values and prevent them being overwritten with the defaults.

The endpoint is restricted to users with the `manage:system` permission.

I see on the `feature/newlogin` branch a lot of the authentication code has changed so if you want me to base it off of that branch and target it for the PR then just let me know 👍