### PR TITLE
Change ‘discordapp.com’ to ‘discord.com’

### DIFF
--- a/server/modules/authentication/discord/authentication.js
+++ b/server/modules/authentication/discord/authentication.js
@@ -13,7 +13,7 @@ module.exports = {
       new DiscordStrategy({
         clientID: conf.clientId,
         clientSecret: conf.clientSecret,
-        authorizationURL: 'https://discordapp.com/api/oauth2/authorize?prompt=none',
+        authorizationURL: 'https://discord.com/api/oauth2/authorize?prompt=none',
         callbackURL: conf.callbackURL,
         scope: 'identify email guilds'
       }, async (accessToken, refreshToken, profile, cb) => {


### PR DESCRIPTION
Discord has updated their API endpoint due to a branding change. App developers are advised to begin updating integrations to prevent being affected by the breaking change which starts November 7th, 2020.

