### PR TITLE
fix: user "undefined" error on deletePage by git storage

### DIFF
--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -184,6 +184,7 @@ module.exports = {
 
           const contentPath = pageHelper.getPagePath(item.relPath)
           await WIKI.models.pages.deletePage({
+            user: user,
             path: contentPath.path,
             locale: contentPath.locale,
             skipStorage: true


### PR DESCRIPTION
Hi, 
based on this issue https://github.com/Requarks/wiki/issues/2114 I noticed that the user object was not passed to the WIKI.models.pages.deletePage function, so when a page was deleted on the git repository the error was reported with user: "undefined" .

