### PR TITLE
misc: update postgresql chart dependency

### DIFF
--- a/dev/helm/Chart.yaml
+++ b/dev/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wiki
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.1
+version: 2.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 AppVersion: latest
@@ -25,8 +25,8 @@ keywords:
 type: application
 dependencies:
   - name: postgresql
-    version: 6.5.0
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    version: 8.10.14
+    repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
 home: https://wiki.js.org
 icon: https://github.com/Requarks/wiki/raw/master/client/static/favicons/android-chrome-192x192.png


### PR DESCRIPTION
The postgresql chart in the stable repository has been [deprecated](https://github.com/helm/charts/tree/master/stable/postgresql#this-helm-chart-is-deprecated).

Updated the dependency to point to the new chart at [bitnami/charts](https://github.com/bitnami/charts/).