### PR TITLE
feat: add 2 more nesting levels for toc

### DIFF
--- a/client/components/admin/admin-theme.vue
+++ b/client/components/admin/admin-theme.vue
@@ -68,6 +68,40 @@
                     hint='Select whether the table of contents is shown on the left, right or not at all.'
                     disabled
                     )
+                  v-radio-group(
+                    row
+                    outlined
+                    persistent-hint
+                    prepend-icon='mdi-serial-port'
+                    v-model='config.tocLevel'
+                    label='Max Heading Level'
+                    hint='The table of contents will show headings up to the selected level. By default, only heading levels up to H2 are shown.'
+                  )
+                    v-spacer
+                    v-radio(
+                      label='H1'
+                      v-bind:value='1'
+                    )
+                    v-radio(
+                      label='H2'
+                      v-bind:value='2'
+                    )
+                    v-radio(
+                      label='H3'
+                      v-bind:value='3'
+                    )
+                    v-radio(
+                      label='H4'
+                      v-bind:value='4'
+                    )
+                    v-radio(
+                      label='H5'
+                      v-bind:value='5'
+                    )
+                    v-radio(
+                      label='H6'
+                      v-bind:value='6'
+                    )
 
             v-flex(lg6 xs12)
               v-card.animated.fadeInUp.wait-p2s
@@ -154,6 +188,7 @@ export default {
       config: {
         theme: 'default',
         darkMode: false,
+        tocLevel: 2,
         iconset: '',
         injectCSS: '',
         injectHead: '',
@@ -209,6 +244,7 @@ export default {
             theme: this.config.theme,
             iconset: this.config.iconset,
             darkMode: this.darkMode,
+            tocLevel: parseInt(this.config.tocLevel, 10),
             injectCSS: this.config.injectCSS,
             injectHead: this.config.injectHead,
             injectBody: this.config.injectBody

--- a/client/components/admin/admin-theme.vue
+++ b/client/components/admin/admin-theme.vue
@@ -102,6 +102,41 @@
                       label='H6'
                       v-bind:value='6'
                     )
+                  v-radio-group(
+                    row
+                    outlined
+                    persistent-hint
+                    prepend-icon='mdi-serial-port'
+                    v-model='config.tocCollapseLevel'
+                    label='Collapse Heading Level'
+                    hint='The table of contents will collapse headings starting from the selected level. By default, only heading levels from H2 are collapsed.'
+                  )
+                    v-spacer
+                    v-radio(
+                      label='H1'
+                      v-bind:value='1'
+                    )
+                    v-radio(
+                      label='H2'
+                      v-bind:value='2'
+                    )
+                    v-radio(
+                      label='H3'
+                      v-bind:value='3'
+                    )
+                    v-radio(
+                      label='H4'
+                      v-bind:value='4'
+                    )
+                    v-radio(
+                      label='H5'
+                      v-bind:value='5'
+                    )
+                    v-radio(
+                      label='H6'
+                      v-bind:value='6'
+                    )
+
 
             v-flex(lg6 xs12)
               v-card.animated.fadeInUp.wait-p2s
@@ -189,6 +224,7 @@ export default {
         theme: 'default',
         darkMode: false,
         tocLevel: 2,
+        tocCollapseLevel: 2,
         iconset: '',
         injectCSS: '',
         injectHead: '',
@@ -245,6 +281,7 @@ export default {
             iconset: this.config.iconset,
             darkMode: this.darkMode,
             tocLevel: parseInt(this.config.tocLevel, 10),
+            tocCollapseLevel: parseInt(this.config.tocCollapseLevel, 10),
             injectCSS: this.config.injectCSS,
             injectHead: this.config.injectHead,
             injectBody: this.config.injectBody

--- a/client/components/editor.vue
+++ b/client/components/editor.vue
@@ -148,6 +148,10 @@ export default {
       type: Number,
       default: 0
     },
+    tocCollapseLevel: {
+      type: Number,
+      default: 0
+    },
     checkoutDate: {
       type: String,
       default: new Date().toISOString()
@@ -195,6 +199,7 @@ export default {
         this.savedState.title !== this.$store.get('page/title'),
         this.savedState.description !== this.$store.get('page/description'),
         this.savedState.tocLevel !== this.$store.get('page/tocLevel'),
+        this.savedState.tocCollapseLevel !== this.$store.get('page/tocCollapseLevel'),
         this.savedState.tags !== this.$store.get('page/tags'),
         this.savedState.isPublished !== this.$store.get('page/isPublished'),
         this.savedState.publishStartDate !== this.$store.get('page/publishStartDate'),
@@ -229,6 +234,7 @@ export default {
     this.$store.set('page/scriptCss', this.scriptCss)
     this.$store.set('page/scriptJs', this.scriptJs)
     this.$store.set('page/tocLevel', this.tocLevel)
+    this.$store.set('page/tocCollapseLevel', this.tocCollapseLevel)
 
     this.$store.set('page/mode', 'edit')
 
@@ -310,6 +316,7 @@ export default {
                 $scriptCss: String
                 $scriptJs: String
                 $tocLevel: Int!
+                $tocCollapseLevel: Int!
                 $tags: [String]!
                 $title: String!
               ) {
@@ -327,6 +334,7 @@ export default {
                     scriptCss: $scriptCss
                     scriptJs: $scriptJs
                     tocLevel: $tocLevel
+                    tocCollapseLevel: $tocCollapseLevel
                     tags: $tags
                     title: $title
                   ) {
@@ -357,6 +365,7 @@ export default {
               scriptCss: this.$store.get('page/scriptCss'),
               scriptJs: this.$store.get('page/scriptJs'),
               tocLevel: this.$store.get('page/tocLevel'),
+              tocCollapseLevel: this.$store.get('page/tocCollapseLevel'),
               tags: this.$store.get('page/tags'),
               title: this.$store.get('page/title')
             }
@@ -417,6 +426,7 @@ export default {
                 $scriptCss: String
                 $scriptJs: String
                 $tocLevel: Int
+                $tocCollapseLevel: Int
                 $tags: [String]
                 $title: String
               ) {
@@ -435,6 +445,7 @@ export default {
                     scriptCss: $scriptCss
                     scriptJs: $scriptJs
                     tocLevel: $tocLevel
+                    tocCollapseLevel: $tocCollapseLevel
                     tags: $tags
                     title: $title
                   ) {
@@ -465,6 +476,7 @@ export default {
               scriptCss: this.$store.get('page/scriptCss'),
               scriptJs: this.$store.get('page/scriptJs'),
               tocLevel: this.$store.get('page/tocLevel'),
+              tocCollapseLevel: this.$store.get('page/tocCollapseLevel'),
               tags: this.$store.get('page/tags'),
               title: this.$store.get('page/title')
             }
@@ -548,7 +560,8 @@ export default {
         title: this.$store.get('page/title'),
         css: this.$store.get('page/scriptCss'),
         js: this.$store.get('page/scriptJs'),
-        tocLevel: this.$store.get('page/tocLevel')
+        tocLevel: this.$store.get('page/tocLevel'),
+        tocCollapseLevel: this.$store.get('page/tocCollapseLevel')
       }
     },
     injectCustomCss: _.debounce(css => {

--- a/client/components/editor.vue
+++ b/client/components/editor.vue
@@ -144,6 +144,10 @@ export default {
       type: Number,
       default: 0
     },
+    tocLevel: {
+      type: Number,
+      default: 0
+    },
     checkoutDate: {
       type: String,
       default: new Date().toISOString()
@@ -190,6 +194,7 @@ export default {
         this.path !== this.$store.get('page/path'),
         this.savedState.title !== this.$store.get('page/title'),
         this.savedState.description !== this.$store.get('page/description'),
+        this.savedState.tocLevel !== this.$store.get('page/tocLevel'),
         this.savedState.tags !== this.$store.get('page/tags'),
         this.savedState.isPublished !== this.$store.get('page/isPublished'),
         this.savedState.publishStartDate !== this.$store.get('page/publishStartDate'),
@@ -223,6 +228,7 @@ export default {
     this.$store.set('page/title', this.title)
     this.$store.set('page/scriptCss', this.scriptCss)
     this.$store.set('page/scriptJs', this.scriptJs)
+    this.$store.set('page/tocLevel', this.tocLevel)
 
     this.$store.set('page/mode', 'edit')
 
@@ -303,6 +309,7 @@ export default {
                 $publishStartDate: Date
                 $scriptCss: String
                 $scriptJs: String
+                $tocLevel: Int!
                 $tags: [String]!
                 $title: String!
               ) {
@@ -319,6 +326,7 @@ export default {
                     publishStartDate: $publishStartDate
                     scriptCss: $scriptCss
                     scriptJs: $scriptJs
+                    tocLevel: $tocLevel
                     tags: $tags
                     title: $title
                   ) {
@@ -348,6 +356,7 @@ export default {
               publishStartDate: this.$store.get('page/publishStartDate') || '',
               scriptCss: this.$store.get('page/scriptCss'),
               scriptJs: this.$store.get('page/scriptJs'),
+              tocLevel: this.$store.get('page/tocLevel'),
               tags: this.$store.get('page/tags'),
               title: this.$store.get('page/title')
             }
@@ -407,6 +416,7 @@ export default {
                 $publishStartDate: Date
                 $scriptCss: String
                 $scriptJs: String
+                $tocLevel: Int
                 $tags: [String]
                 $title: String
               ) {
@@ -424,6 +434,7 @@ export default {
                     publishStartDate: $publishStartDate
                     scriptCss: $scriptCss
                     scriptJs: $scriptJs
+                    tocLevel: $tocLevel
                     tags: $tags
                     title: $title
                   ) {
@@ -453,6 +464,7 @@ export default {
               publishStartDate: this.$store.get('page/publishStartDate') || '',
               scriptCss: this.$store.get('page/scriptCss'),
               scriptJs: this.$store.get('page/scriptJs'),
+              tocLevel: this.$store.get('page/tocLevel'),
               tags: this.$store.get('page/tags'),
               title: this.$store.get('page/title')
             }
@@ -535,7 +547,8 @@ export default {
         tags: this.$store.get('page/tags'),
         title: this.$store.get('page/title'),
         css: this.$store.get('page/scriptCss'),
-        js: this.$store.get('page/scriptJs')
+        js: this.$store.get('page/scriptJs'),
+        tocLevel: this.$store.get('page/tocLevel')
       }
     },
     injectCustomCss: _.debounce(css => {

--- a/client/components/editor/editor-modal-properties.vue
+++ b/client/components/editor/editor-modal-properties.vue
@@ -106,6 +106,44 @@
                 label='H6'
                 v-bind:value='6'
               )
+            v-radio-group(
+              row
+              outlined
+              persistent-hint
+              prepend-icon='mdi-serial-port'
+              v-model='tocCollapseLevel'
+              label='Collapse Heading Level'
+              hint='The table of contents will collapse headings starting from the selected level. By default, only heading levels from H2 are collapsed.'
+            )
+              v-spacer
+              v-radio(
+                label='Global'
+                v-bind:value='0'
+              )
+              v-radio(
+                label='H1'
+                v-bind:value='1'
+              )
+              v-radio(
+                label='H2'
+                v-bind:value='2'
+              )
+              v-radio(
+                label='H3'
+                v-bind:value='3'
+              )
+              v-radio(
+                label='H4'
+                v-bind:value='4'
+              )
+              v-radio(
+                label='H5'
+                v-bind:value='5'
+              )
+              v-radio(
+                label='H6'
+                v-bind:value='6'
+              )
           v-divider
           v-card-text.grey.pt-5(:class='$vuetify.theme.dark ? `darken-3-d5` : `lighten-4`')
             .overline.pb-5 {{$t('editor:props.categorization')}}
@@ -331,6 +369,7 @@ export default {
     publishStartDate: sync('page/publishStartDate'),
     publishEndDate: sync('page/publishEndDate'),
     tocLevel: sync('page/tocLevel'),
+    tocCollapseLevel: sync('page/tocCollapseLevel'),
     scriptJs: sync('page/scriptJs'),
     scriptCss: sync('page/scriptCss'),
     hasScriptPermission: get('page/effectivePermissions@pages.script'),

--- a/client/components/editor/editor-modal-properties.vue
+++ b/client/components/editor/editor-modal-properties.vue
@@ -66,6 +66,47 @@
                     @click:append='showPathSelector'
                     )
           v-divider
+          v-card-text.grey.pt-5(:class='$vuetify.theme.dark ? `darken-3-d3` : `lighten-5`')
+            .overline.pb-5 Theme Options
+            v-radio-group(
+              row
+              outlined
+              persistent-hint
+              prepend-icon='mdi-serial-port'
+              v-model='tocLevel'
+              label='Max Heading Level'
+              hint='The table of contents will show headings up to the selected level. By default, only heading levels up to H2 are shown.'
+            )
+              v-spacer
+              v-radio(
+                label='Global'
+                v-bind:value='0'
+              )
+              v-radio(
+                label='H1'
+                v-bind:value='1'
+              )
+              v-radio(
+                label='H2'
+                v-bind:value='2'
+              )
+              v-radio(
+                label='H3'
+                v-bind:value='3'
+              )
+              v-radio(
+                label='H4'
+                v-bind:value='4'
+              )
+              v-radio(
+                label='H5'
+                v-bind:value='5'
+              )
+              v-radio(
+                label='H6'
+                v-bind:value='6'
+              )
+          v-divider
           v-card-text.grey.pt-5(:class='$vuetify.theme.dark ? `darken-3-d5` : `lighten-4`')
             .overline.pb-5 {{$t('editor:props.categorization')}}
             v-chip-group.radius-5.mb-5(column, v-if='tags && tags.length > 0')
@@ -289,6 +330,7 @@ export default {
     isPublished: sync('page/isPublished'),
     publishStartDate: sync('page/publishStartDate'),
     publishEndDate: sync('page/publishEndDate'),
+    tocLevel: sync('page/tocLevel'),
     scriptJs: sync('page/scriptJs'),
     scriptCss: sync('page/scriptCss'),
     hasScriptPermission: get('page/effectivePermissions@pages.script'),

--- a/client/graph/admin/theme/theme-mutation-save.gql
+++ b/client/graph/admin/theme/theme-mutation-save.gql
@@ -1,6 +1,6 @@
-mutation($theme: String!, $iconset: String!, $darkMode: Boolean!, $injectCSS: String, $injectHead: String, $injectBody: String) {
+mutation($theme: String!, $iconset: String!, $darkMode: Boolean!, $tocLevel: Int!, $injectCSS: String, $injectHead: String, $injectBody: String) {
   theming {
-    setConfig(theme: $theme, iconset: $iconset, darkMode: $darkMode, injectCSS: $injectCSS, injectHead: $injectHead, injectBody: $injectBody) {
+    setConfig(theme: $theme, iconset: $iconset, darkMode: $darkMode, tocLevel: $tocLevel, injectCSS: $injectCSS, injectHead: $injectHead, injectBody: $injectBody) {
       responseResult {
         succeeded
         errorCode

--- a/client/graph/admin/theme/theme-mutation-save.gql
+++ b/client/graph/admin/theme/theme-mutation-save.gql
@@ -1,6 +1,6 @@
-mutation($theme: String!, $iconset: String!, $darkMode: Boolean!, $tocLevel: Int!, $injectCSS: String, $injectHead: String, $injectBody: String) {
+mutation($theme: String!, $iconset: String!, $darkMode: Boolean!, $tocLevel: Int!, $tocCollapseLevel: Int!, $injectCSS: String, $injectHead: String, $injectBody: String) {
   theming {
-    setConfig(theme: $theme, iconset: $iconset, darkMode: $darkMode, tocLevel: $tocLevel, injectCSS: $injectCSS, injectHead: $injectHead, injectBody: $injectBody) {
+    setConfig(theme: $theme, iconset: $iconset, darkMode: $darkMode, tocLevel: $tocLevel, tocCollapseLevel: $tocCollapseLevel, injectCSS: $injectCSS, injectHead: $injectHead, injectBody: $injectBody) {
       responseResult {
         succeeded
         errorCode

--- a/client/graph/admin/theme/theme-query-config.gql
+++ b/client/graph/admin/theme/theme-query-config.gql
@@ -4,6 +4,7 @@ query {
       theme
       iconset
       darkMode
+      tocLevel
       injectCSS
       injectHead
       injectBody

--- a/client/graph/admin/theme/theme-query-config.gql
+++ b/client/graph/admin/theme/theme-query-config.gql
@@ -5,6 +5,7 @@ query {
       iconset
       darkMode
       tocLevel
+      tocCollapseLevel
       injectCSS
       injectHead
       injectBody

--- a/client/store/page.js
+++ b/client/store/page.js
@@ -16,7 +16,8 @@ const state = {
   updatedAt: '',
   mode: '',
   scriptJs: '',
-  tocLevel: 0,
+  tocLevel: 2,
+  tocCollapseLevel: 2,
   scriptCss: '',
   effectivePermissions: {
     comments: {

--- a/client/store/page.js
+++ b/client/store/page.js
@@ -16,6 +16,7 @@ const state = {
   updatedAt: '',
   mode: '',
   scriptJs: '',
+  tocLevel: 0,
   scriptCss: '',
   effectivePermissions: {
     comments: {

--- a/client/themes/default/components/page-toc-item.vue
+++ b/client/themes/default/components/page-toc-item.vue
@@ -1,0 +1,74 @@
+<template lang="pug">
+  div
+    v-list-item(@click='click(item.anchor)', v-if='(item.children.length === 0 || tocLevel === level) || tocCollapseLevel > level',
+      :key='item.anchor', :class='isNestedLevel ? `pl-9` : `pl-6`')
+      v-icon.pl-0(small, color='grey lighten-1') {{ $vuetify.rtl ? `mdi-chevron-left` : `mdi-chevron-right` }}
+      v-list-item-title.pl-4(v-bind:class='titleClasses') {{item.title}}
+    v-list-group(sub-group, v-else, v-bind:class='{"pl-3": isNestedLevel}')
+      template(v-slot:activator)
+        v-list-item.pl-0(@click='click(item.anchor)', :key='item.anchor')
+          v-list-item-title(v-bind:class='titleClasses') {{item.title}}
+      template(v-if='tocLevel > level', v-for='subItem in item.children')
+        page-toc-item(:item='subItem', :level='level + 1', :tocLevel='tocLevel', :tocCollapseLevel='tocCollapseLevel')
+    template(v-if='tocCollapseLevel > level', v-for='subItem in item.children')
+      page-toc-item(:item='subItem', :level='level + 1', :tocLevel='tocLevel', :tocCollapseLevel='tocCollapseLevel')
+</template>
+
+<script>
+
+export default {
+  name: "pageTocItem",
+  props: {
+    item: {
+      type: Object,
+      default: () => {}
+    },
+    tocLevel: {
+      type: Number,
+      default: 2
+    },
+    tocCollapseLevel: {
+      type: Number,
+      default: 2
+    },
+    level: {
+      type: Number,
+      default: 1
+    }
+  },
+  data() {
+    return {
+      scrollOpts: {
+        duration: 1500,
+        offset: 0,
+        easing: 'easeInOutCubic'
+      }
+    }
+  },
+  computed: {
+    isNestedLevel() {
+      return this.level > 1
+    },
+    titleClasses() {
+      return {
+        "caption": this.isNestedLevel,
+        "grey--text": this.isNestedLevel,
+        "text--lighten-1": this.$vuetify.theme.dark && this.isNestedLevel,
+        "text--darken-1": !this.$vuetify.theme.dark && this.isNestedLevel
+      }
+    },
+  },
+  methods: {
+    click (anchor) {
+      this.$vuetify.goTo(anchor, this.scrollOpts)
+    }
+  }
+}
+</script>
+
+<style lang='scss'>
+// Hack to fix animations of multi level nesting v-list-group
+.v-list-group--sub-group.v-list-group--active .v-list-item:not(.v-list-item--active) .v-list-item__icon.v-list-group__header__prepend-icon .v-icon {
+  transform: rotate(0deg)!important;
+}
+</style>

--- a/client/themes/default/components/page.vue
+++ b/client/themes/default/components/page.vue
@@ -59,32 +59,9 @@
           v-flex.page-col-sd(lg3, xl2, v-if='$vuetify.breakpoint.lgAndUp')
             v-card.mb-5(v-if='tocDecoded.length')
               .overline.pa-5.pb-0(:class='$vuetify.theme.dark ? `blue--text text--lighten-2` : `primary--text`') {{$t('common:page.toc')}}
-              v-list.pb-3(dense, nav, :class='$vuetify.theme.dark ? `darken-3-d3` : ``')
-                template(v-for='tocItem in tocDecoded')
-                  v-list-item(@click='$vuetify.goTo(tocItem.anchor, scrollOpts)')
-                    v-icon(color='grey', small) {{ $vuetify.rtl ? `mdi-chevron-left` : `mdi-chevron-right` }}
-                    v-list-item-title.px-3 {{tocItem.title}}
-                  template(v-for='tocSubItem in tocItem.children', v-if='tocLevel > 1')
-                    v-list-item(@click='$vuetify.goTo(tocSubItem.anchor, scrollOpts)')
-                      v-icon.pl-3(color='grey lighten-1', small) {{ $vuetify.rtl ? `mdi-chevron-left` : `mdi-chevron-right` }}
-                      v-list-item-title.pl-3.caption.grey--text(:class='$vuetify.theme.dark ? `text--lighten-3` : `text--darken-4`') {{tocSubItem.title}}
-                    template(v-for='tocSubItem2nd in tocSubItem.children', v-if='tocLevel > 2')
-                      v-list-item(@click='$vuetify.goTo(tocSubItem2nd.anchor, scrollOpts)')
-                        v-icon.pl-6(color='grey lighten-1', small) {{ $vuetify.rtl ? `mdi-chevron-left` : `mdi-chevron-right` }}
-                        v-list-item-title.pl-3.caption.grey--text(:class='$vuetify.theme.dark ? `text--lighten-4` : `text--darken-3`') {{tocSubItem2nd.title}}
-                      template(v-for='tocSubItem3rd in tocSubItem2nd.children', v-if='tocLevel > 3')
-                        v-list-item(@click='$vuetify.goTo(tocSubItem3rd.anchor, scrollOpts)')
-                          v-icon.pl-9(color='grey lighten-1', small) {{ $vuetify.rtl ? `mdi-chevron-left` : `mdi-chevron-right` }}
-                          v-list-item-title.pl-3.caption.grey--text(:class='$vuetify.theme.dark ? `text--lighten-5` : `text--darken-2`') {{tocSubItem3rd.title}}
-                        template(v-for='tocSubItem4th in tocSubItem3rd.children', v-if='tocLevel > 4')
-                          v-list-item(@click='$vuetify.goTo(tocSubItem4th.anchor, scrollOpts)')
-                            v-icon.pl-12(color='grey lighten-1', small) {{ $vuetify.rtl ? `mdi-chevron-left` : `mdi-chevron-right` }}
-                            v-list-item-title.pl-3.caption.grey--text(:class='$vuetify.theme.dark ? `text--lighten-5` : `text--darken-2`') {{tocSubItem4th.title}}
-                          template(v-for='tocSubItem5th in tocSubItem4th.children', v-if='tocLevel > 5')
-                            v-list-item(@click='$vuetify.goTo(tocSubItem5th.anchor, scrollOpts)')
-                              v-icon.pl-15(color='grey lighten-1', small) {{ $vuetify.rtl ? `mdi-chevron-left` : `mdi-chevron-right` }}
-                              v-list-item-title.pl-3.caption.grey--text(:class='$vuetify.theme.dark ? `text--lighten-5` : `text--darken-2`') {{tocSubItem5th.title}}
-
+              v-list.py-0(dense, nav, :class='$vuetify.theme.dark ? `darken-3-d3` : ``')
+                template(v-for='item in tocDecoded')
+                  page-toc-item(:item='item', :tocLevel='tocLevel', :tocCollapseLevel='tocCollapseLevel')
             v-card.mb-5(v-if='tags.length > 0')
               .pa-5
                 .overline.teal--text.pb-2(:class='$vuetify.theme.dark ? `text--lighten-3` : ``') {{$t('common:page.tags')}}
@@ -321,6 +298,7 @@
 import { StatusIndicator } from 'vue-status-indicator'
 import Tabset from './tabset.vue'
 import NavSidebar from './nav-sidebar.vue'
+import PageTocItem from './page-toc-item.vue'
 import Prism from 'prismjs'
 import mermaid from 'mermaid'
 import { get, sync } from 'vuex-pathify'
@@ -368,6 +346,7 @@ Prism.plugins.toolbar.registerButton('copy-to-clipboard', (env) => {
 export default {
   components: {
     NavSidebar,
+    PageTocItem,
     StatusIndicator
   },
   props: {
@@ -443,6 +422,10 @@ export default {
       type: Number,
       default: 2
     },
+    tocCollapseLevel: {
+      type: Number,
+      default: 2
+    }
   },
   data() {
     return {

--- a/client/themes/default/components/page.vue
+++ b/client/themes/default/components/page.vue
@@ -60,16 +60,30 @@
             v-card.mb-5(v-if='tocDecoded.length')
               .overline.pa-5.pb-0(:class='$vuetify.theme.dark ? `blue--text text--lighten-2` : `primary--text`') {{$t('common:page.toc')}}
               v-list.pb-3(dense, nav, :class='$vuetify.theme.dark ? `darken-3-d3` : ``')
-                template(v-for='(tocItem, tocIdx) in tocDecoded')
+                template(v-for='tocItem in tocDecoded')
                   v-list-item(@click='$vuetify.goTo(tocItem.anchor, scrollOpts)')
                     v-icon(color='grey', small) {{ $vuetify.rtl ? `mdi-chevron-left` : `mdi-chevron-right` }}
                     v-list-item-title.px-3 {{tocItem.title}}
-                  //- v-divider(v-if='tocIdx < toc.length - 1 || tocItem.children.length')
-                  template(v-for='tocSubItem in tocItem.children')
+                  template(v-for='tocSubItem in tocItem.children', v-if='tocLevel > 1')
                     v-list-item(@click='$vuetify.goTo(tocSubItem.anchor, scrollOpts)')
-                      v-icon.px-3(color='grey lighten-1', small) {{ $vuetify.rtl ? `mdi-chevron-left` : `mdi-chevron-right` }}
-                      v-list-item-title.px-3.caption.grey--text(:class='$vuetify.theme.dark ? `text--lighten-1` : `text--darken-1`') {{tocSubItem.title}}
-                    //- v-divider(inset, v-if='tocIdx < toc.length - 1')
+                      v-icon.pl-3(color='grey lighten-1', small) {{ $vuetify.rtl ? `mdi-chevron-left` : `mdi-chevron-right` }}
+                      v-list-item-title.pl-3.caption.grey--text(:class='$vuetify.theme.dark ? `text--lighten-3` : `text--darken-4`') {{tocSubItem.title}}
+                    template(v-for='tocSubItem2nd in tocSubItem.children', v-if='tocLevel > 2')
+                      v-list-item(@click='$vuetify.goTo(tocSubItem2nd.anchor, scrollOpts)')
+                        v-icon.pl-6(color='grey lighten-1', small) {{ $vuetify.rtl ? `mdi-chevron-left` : `mdi-chevron-right` }}
+                        v-list-item-title.pl-3.caption.grey--text(:class='$vuetify.theme.dark ? `text--lighten-4` : `text--darken-3`') {{tocSubItem2nd.title}}
+                      template(v-for='tocSubItem3rd in tocSubItem2nd.children', v-if='tocLevel > 3')
+                        v-list-item(@click='$vuetify.goTo(tocSubItem3rd.anchor, scrollOpts)')
+                          v-icon.pl-9(color='grey lighten-1', small) {{ $vuetify.rtl ? `mdi-chevron-left` : `mdi-chevron-right` }}
+                          v-list-item-title.pl-3.caption.grey--text(:class='$vuetify.theme.dark ? `text--lighten-5` : `text--darken-2`') {{tocSubItem3rd.title}}
+                        template(v-for='tocSubItem4th in tocSubItem3rd.children', v-if='tocLevel > 4')
+                          v-list-item(@click='$vuetify.goTo(tocSubItem4th.anchor, scrollOpts)')
+                            v-icon.pl-12(color='grey lighten-1', small) {{ $vuetify.rtl ? `mdi-chevron-left` : `mdi-chevron-right` }}
+                            v-list-item-title.pl-3.caption.grey--text(:class='$vuetify.theme.dark ? `text--lighten-5` : `text--darken-2`') {{tocSubItem4th.title}}
+                          template(v-for='tocSubItem5th in tocSubItem4th.children', v-if='tocLevel > 5')
+                            v-list-item(@click='$vuetify.goTo(tocSubItem5th.anchor, scrollOpts)')
+                              v-icon.pl-15(color='grey lighten-1', small) {{ $vuetify.rtl ? `mdi-chevron-left` : `mdi-chevron-right` }}
+                              v-list-item-title.pl-3.caption.grey--text(:class='$vuetify.theme.dark ? `text--lighten-5` : `text--darken-2`') {{tocSubItem5th.title}}
 
             v-card.mb-5(v-if='tags.length > 0')
               .pa-5
@@ -424,7 +438,11 @@ export default {
     commentsExternal: {
       type: Boolean,
       default: false
-    }
+    },
+    tocLevel: {
+      type: Number,
+      default: 2
+    },
   },
   data() {
     return {

--- a/server/app/data.yml
+++ b/server/app/data.yml
@@ -53,6 +53,7 @@ defaults:
       theme: 'default'
       iconset: 'md'
       darkMode: false
+      tocLevel: 2
     auth:
       autoLogin: false
       enforce2FA: false

--- a/server/app/data.yml
+++ b/server/app/data.yml
@@ -54,6 +54,7 @@ defaults:
       iconset: 'md'
       darkMode: false
       tocLevel: 2
+      tocCollapseLevel: 2
     auth:
       autoLogin: false
       enforce2FA: false

--- a/server/controllers/common.js
+++ b/server/controllers/common.js
@@ -464,6 +464,8 @@ router.get('/*', async (req, res, next) => {
           injectCode.body = `${injectCode.body}\n${page.extra.js}`
         }
 
+        const tocLevel = page.tocLevel || WIKI.config.theming.tocLevel
+
         if (req.query.legacy || req.get('user-agent').indexOf('Trident') >= 0) {
           // -> Convert page TOC
           if (_.isString(page.toc)) {
@@ -474,6 +476,7 @@ router.get('/*', async (req, res, next) => {
           res.render('legacy/page', {
             page,
             sidebar,
+            tocLevel,
             injectCode,
             isAuthenticated: req.user && req.user.id !== 2
           })
@@ -499,6 +502,7 @@ router.get('/*', async (req, res, next) => {
           res.render('page', {
             page,
             sidebar,
+            tocLevel,
             injectCode,
             comments: WIKI.data.commentProvider,
             effectivePermissions

--- a/server/controllers/common.js
+++ b/server/controllers/common.js
@@ -465,6 +465,7 @@ router.get('/*', async (req, res, next) => {
         }
 
         const tocLevel = page.tocLevel || WIKI.config.theming.tocLevel
+        const tocCollapseLevel = page.tocCollapseLevel || WIKI.config.theming.tocCollapseLevel
 
         if (req.query.legacy || req.get('user-agent').indexOf('Trident') >= 0) {
           // -> Convert page TOC
@@ -477,6 +478,7 @@ router.get('/*', async (req, res, next) => {
             page,
             sidebar,
             tocLevel,
+            tocCollapseLevel,
             injectCode,
             isAuthenticated: req.user && req.user.id !== 2
           })
@@ -503,6 +505,7 @@ router.get('/*', async (req, res, next) => {
             page,
             sidebar,
             tocLevel,
+            tocCollapseLevel,
             injectCode,
             comments: WIKI.data.commentProvider,
             effectivePermissions

--- a/server/db/migrations-sqlite/2.5.13.js
+++ b/server/db/migrations-sqlite/2.5.13.js
@@ -2,6 +2,7 @@ exports.up = async knex => {
   await knex.schema
     .alterTable('pages', table => {
       table.integer('tocLevel').notNullable().defaultTo(0)
+      table.integer('tocCollapseLevel').notNullable().defaultTo(0)
     })
 }
 

--- a/server/db/migrations-sqlite/2.5.13.js
+++ b/server/db/migrations-sqlite/2.5.13.js
@@ -1,0 +1,8 @@
+exports.up = async knex => {
+  await knex.schema
+    .alterTable('pages', table => {
+      table.integer('tocLevel').notNullable().defaultTo(0)
+    })
+}
+
+exports.down = knex => { }

--- a/server/db/migrations/2.5.13.js
+++ b/server/db/migrations/2.5.13.js
@@ -2,6 +2,7 @@ exports.up = async knex => {
   await knex.schema
     .alterTable('pages', table => {
       table.integer('tocLevel').notNullable().defaultTo(0)
+      table.integer('tocCollapseLevel').notNullable().defaultTo(0)
     })
 }
 

--- a/server/db/migrations/2.5.13.js
+++ b/server/db/migrations/2.5.13.js
@@ -1,0 +1,8 @@
+exports.up = async knex => {
+  await knex.schema
+    .alterTable('pages', table => {
+      table.integer('tocLevel').notNullable().defaultTo(0)
+    })
+}
+
+exports.down = knex => { }

--- a/server/graph/resolvers/theming.js
+++ b/server/graph/resolvers/theming.js
@@ -25,6 +25,7 @@ module.exports = {
         iconset: WIKI.config.theming.iconset,
         darkMode: WIKI.config.theming.darkMode,
         tocLevel: WIKI.config.theming.tocLevel,
+        tocCollapseLevel: WIKI.config.theming.tocCollapseLevel,
         injectCSS: new CleanCSS({ format: 'beautify' }).minify(WIKI.config.theming.injectCSS).styles,
         injectHead: WIKI.config.theming.injectHead,
         injectBody: WIKI.config.theming.injectBody
@@ -46,6 +47,7 @@ module.exports = {
           iconset: args.iconset,
           darkMode: args.darkMode,
           tocLevel: args.tocLevel,
+          tocCollapseLevel: args.tocCollapseLevel,
           injectCSS: args.injectCSS || '',
           injectHead: args.injectHead || '',
           injectBody: args.injectBody || ''

--- a/server/graph/resolvers/theming.js
+++ b/server/graph/resolvers/theming.js
@@ -24,6 +24,7 @@ module.exports = {
         theme: WIKI.config.theming.theme,
         iconset: WIKI.config.theming.iconset,
         darkMode: WIKI.config.theming.darkMode,
+        tocLevel: WIKI.config.theming.tocLevel,
         injectCSS: new CleanCSS({ format: 'beautify' }).minify(WIKI.config.theming.injectCSS).styles,
         injectHead: WIKI.config.theming.injectHead,
         injectBody: WIKI.config.theming.injectBody
@@ -44,6 +45,7 @@ module.exports = {
           theme: args.theme,
           iconset: args.iconset,
           darkMode: args.darkMode,
+          tocLevel: args.tocLevel,
           injectCSS: args.injectCSS || '',
           injectHead: args.injectHead || '',
           injectBody: args.injectBody || ''

--- a/server/graph/schemas/page.graphql
+++ b/server/graph/schemas/page.graphql
@@ -94,6 +94,7 @@ type PageMutation {
     tags: [String]!
     title: String!
     tocLevel: Int
+    tocCollapseLevel: Int
   ): PageResponse @auth(requires: ["write:pages", "manage:pages", "manage:system"])
 
   update(
@@ -112,6 +113,7 @@ type PageMutation {
     tags: [String]
     title: String
     tocLevel: Int
+    tocCollapseLevel: Int
   ): PageResponse @auth(requires: ["write:pages", "manage:pages", "manage:system"])
 
   move(
@@ -183,6 +185,7 @@ type Page {
   render: String
   toc: String
   tocLevel: Int!
+  tocCollapseLevel: Int!
   contentType: String!
   createdAt: Date!
   updatedAt: Date!

--- a/server/graph/schemas/page.graphql
+++ b/server/graph/schemas/page.graphql
@@ -93,6 +93,7 @@ type PageMutation {
     scriptJs: String
     tags: [String]!
     title: String!
+    tocLevel: Int
   ): PageResponse @auth(requires: ["write:pages", "manage:pages", "manage:system"])
 
   update(
@@ -110,6 +111,7 @@ type PageMutation {
     scriptJs: String
     tags: [String]
     title: String
+    tocLevel: Int
   ): PageResponse @auth(requires: ["write:pages", "manage:pages", "manage:system"])
 
   move(
@@ -180,6 +182,7 @@ type Page {
   content: String! @auth(requires: ["read:source", "write:pages", "manage:system"])
   render: String
   toc: String
+  tocLevel: Int!
   contentType: String!
   createdAt: Date!
   updatedAt: Date!

--- a/server/graph/schemas/theming.graphql
+++ b/server/graph/schemas/theming.graphql
@@ -28,6 +28,7 @@ type ThemingMutation {
     theme: String!
     iconset: String!
     darkMode: Boolean!
+    tocLevel: Int!
     injectCSS: String
     injectHead: String
     injectBody: String
@@ -42,6 +43,7 @@ type ThemingConfig {
   theme: String!
   iconset: String!
   darkMode: Boolean!
+  tocLevel: Int!
   injectCSS: String
   injectHead: String
   injectBody: String

--- a/server/graph/schemas/theming.graphql
+++ b/server/graph/schemas/theming.graphql
@@ -29,6 +29,7 @@ type ThemingMutation {
     iconset: String!
     darkMode: Boolean!
     tocLevel: Int!
+    tocCollapseLevel: Int!
     injectCSS: String
     injectHead: String
     injectBody: String
@@ -44,6 +45,7 @@ type ThemingConfig {
   iconset: String!
   darkMode: Boolean!
   tocLevel: Int!
+  tocCollapseLevel: Int!
   injectCSS: String
   injectHead: String
   injectBody: String

--- a/server/helpers/page.js
+++ b/server/helpers/page.js
@@ -74,6 +74,9 @@ module.exports = {
       ['tags', page.tags ? page.tags.map(t => t.tag).join(', ') : ''],
       ['editor', page.editorKey]
     ]
+    if (page.tocLevel) {
+      meta.push(['tocLevel', page.tocLevel])
+    }
     switch (page.contentType) {
       case 'markdown':
         return '---\n' + meta.map(mt => `${mt[0]}: ${mt[1]}`).join('\n') + '\n---\n\n' + page.content

--- a/server/helpers/page.js
+++ b/server/helpers/page.js
@@ -77,6 +77,9 @@ module.exports = {
     if (page.tocLevel) {
       meta.push(['tocLevel', page.tocLevel])
     }
+    if (page.tocCollapseLevel) {
+      meta.push(['tocCollapseLevel', page.tocCollapseLevel])
+    }
     switch (page.contentType) {
       case 'markdown':
         return '---\n' + meta.map(mt => `${mt[0]}: ${mt[1]}`).join('\n') + '\n---\n\n' + page.content

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -45,6 +45,7 @@ module.exports = class Page extends Model {
         content: {type: 'string'},
         contentType: {type: 'string'},
         tocLevel: {type: 'integer'},
+        tocCollapseLevel: {type: 'integer'},
         createdAt: {type: 'string'},
         updatedAt: {type: 'string'}
       }
@@ -150,6 +151,7 @@ module.exports = class Page extends Model {
       title: 'string',
       toc: 'string',
       tocLevel: 'uint',
+      tocCollapseLevel: 'uint',
       updatedAt: 'string'
     })
   }
@@ -297,6 +299,7 @@ module.exports = class Page extends Model {
       title: opts.title,
       toc: '[]',
       tocLevel: opts.tocLevel || 0,
+      tocCollapseLevel: opts.tocCollapseLevel || 0,
       extra: JSON.stringify({
         js: scriptJs,
         css: scriptCss
@@ -417,6 +420,7 @@ module.exports = class Page extends Model {
       publishStartDate: opts.publishStartDate || '',
       title: opts.title,
       tocLevel: opts.tocLevel || 0,
+      tocCollapseLevel: opts.tocCollapseLevel || 0,
       extra: JSON.stringify({
         ...ogPage.extra,
         js: scriptJs,
@@ -799,6 +803,7 @@ module.exports = class Page extends Model {
           'pages.render',
           'pages.toc',
           'pages.tocLevel',
+          'pages.tocCollapseLevel',
           'pages.contentType',
           'pages.createdAt',
           'pages.updatedAt',
@@ -879,6 +884,7 @@ module.exports = class Page extends Model {
       title: page.title,
       toc: _.isString(page.toc) ? page.toc : JSON.stringify(page.toc),
       tocLevel: page.tocLevel,
+      tocCollapseLevel: page.tocCollapseLevel,
       updatedAt: page.updatedAt
     }))
   }

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -44,7 +44,7 @@ module.exports = class Page extends Model {
         publishEndDate: {type: 'string'},
         content: {type: 'string'},
         contentType: {type: 'string'},
-
+        tocLevel: {type: 'integer'},
         createdAt: {type: 'string'},
         updatedAt: {type: 'string'}
       }
@@ -149,6 +149,7 @@ module.exports = class Page extends Model {
       },
       title: 'string',
       toc: 'string',
+      tocLevel: 'uint',
       updatedAt: 'string'
     })
   }
@@ -295,6 +296,7 @@ module.exports = class Page extends Model {
       publishStartDate: opts.publishStartDate || '',
       title: opts.title,
       toc: '[]',
+      tocLevel: opts.tocLevel || 0,
       extra: JSON.stringify({
         js: scriptJs,
         css: scriptCss
@@ -414,6 +416,7 @@ module.exports = class Page extends Model {
       publishEndDate: opts.publishEndDate || '',
       publishStartDate: opts.publishStartDate || '',
       title: opts.title,
+      tocLevel: opts.tocLevel || 0,
       extra: JSON.stringify({
         ...ogPage.extra,
         js: scriptJs,
@@ -567,7 +570,7 @@ module.exports = class Page extends Model {
       path: opts.destinationPath,
       mode: 'move'
     })
-   
+
     // -> Reconnect Links : Validate invalid links to the new path
     await WIKI.models.pages.reconnectLinks({
       locale: opts.destinationLocale,
@@ -795,6 +798,7 @@ module.exports = class Page extends Model {
           'pages.content',
           'pages.render',
           'pages.toc',
+          'pages.tocLevel',
           'pages.contentType',
           'pages.createdAt',
           'pages.updatedAt',
@@ -874,6 +878,7 @@ module.exports = class Page extends Model {
       tags: page.tags.map(t => _.pick(t, ['tag', 'title'])),
       title: page.title,
       toc: _.isString(page.toc) ? page.toc : JSON.stringify(page.toc),
+      tocLevel: page.tocLevel,
       updatedAt: page.updatedAt
     }))
   }

--- a/server/modules/storage/disk/common.js
+++ b/server/modules/storage/disk/common.js
@@ -93,6 +93,7 @@ module.exports = {
         isPrivate: false,
         content: pageData.content,
         tocLevel: pageData.tocLevel,
+        tocCollapseLevel: pageData.tocCollapseLevel,
         user: user,
         skipStorage: true
       })
@@ -112,7 +113,8 @@ module.exports = {
         user: user,
         editor: pageEditor,
         skipStorage: true,
-        tocLevel: pageData.tocLevel
+        tocLevel: pageData.tocLevel,
+        tocCollapseLevel: pageData.tocCollapseLevel
       })
     }
   },

--- a/server/modules/storage/disk/common.js
+++ b/server/modules/storage/disk/common.js
@@ -92,6 +92,7 @@ module.exports = {
         isPublished: _.get(pageData, 'isPublished', currentPage.isPublished),
         isPrivate: false,
         content: pageData.content,
+        tocLevel: pageData.tocLevel,
         user: user,
         skipStorage: true
       })
@@ -110,7 +111,8 @@ module.exports = {
         content: pageData.content,
         user: user,
         editor: pageEditor,
-        skipStorage: true
+        skipStorage: true,
+        tocLevel: pageData.tocLevel
       })
     }
   },

--- a/server/setup.js
+++ b/server/setup.js
@@ -127,6 +127,7 @@ module.exports = () => {
         theme: 'default',
         darkMode: false,
         tocLevel: 2,
+        tocCollapseLevel: 2,
         iconset: 'mdi',
         injectCSS: '',
         injectHead: '',

--- a/server/setup.js
+++ b/server/setup.js
@@ -126,6 +126,7 @@ module.exports = () => {
       _.set(WIKI.config, 'theming', {
         theme: 'default',
         darkMode: false,
+        tocLevel: 2,
         iconset: 'mdi',
         injectCSS: '',
         injectHead: '',

--- a/server/views/editor.pug
+++ b/server/views/editor.pug
@@ -20,6 +20,7 @@ block body
       script-js=page.extra.js
       init-mode=page.mode
       :toc-level=page.tocLevel
+      :toc-collapse-level=page.tocCollapseLevel
       init-editor=page.editorKey
       init-content=page.content
       checkout-date=page.updatedAt

--- a/server/views/editor.pug
+++ b/server/views/editor.pug
@@ -19,6 +19,7 @@ block body
       script-css=page.extra.css
       script-js=page.extra.js
       init-mode=page.mode
+      :toc-level=page.tocLevel
       init-editor=page.editorKey
       init-content=page.content
       checkout-date=page.updatedAt

--- a/server/views/page.pug
+++ b/server/views/page.pug
@@ -28,7 +28,8 @@ block body
       comments-enabled=config.features.featurePageComments
       effective-permissions=Buffer.from(JSON.stringify(effectivePermissions)).toString('base64')
       comments-external=comments.codeTemplate
-      toc-level=tocLevel
+      :toc-level=tocLevel
+      :toc-collapse-level=tocCollapseLevel
       )
       template(slot='contents')
         div!= page.render

--- a/server/views/page.pug
+++ b/server/views/page.pug
@@ -28,6 +28,7 @@ block body
       comments-enabled=config.features.featurePageComments
       effective-permissions=Buffer.from(JSON.stringify(effectivePermissions)).toString('base64')
       comments-external=comments.codeTemplate
+      toc-level=tocLevel
       )
       template(slot='contents')
         div!= page.render


### PR DESCRIPTION
fix: #1216
feature request: https://requarks.canny.io/wiki/p/allow-to-select-toc-depth-level (20 votes)
feature discussion at: #1931

To sum up the feature:
1. You can control (globally and per page) the nesting level of the table of contents.
2. You can control from what level, collapsing will occur (globally and per page) so that up to that level all entries will be shown and to see the rest you will need to click the toc entry.
Check out the gif below for a quick overview.

@NGPixel and @fireundubh  I would love to get any comments on the UI/UX as it is not my strong suite.

![toc](https://user-images.githubusercontent.com/5775519/87258367-aed70400-c4ab-11ea-9a60-adf9468c08dd.gif)