### PR TITLE
Add configuration switch "OFFLINE" to docker configuration

### DIFF
--- a/dev/build/config.yml
+++ b/dev/build/config.yml
@@ -16,5 +16,4 @@ ssl:
   domain: $(LETSENCRYPT_DOMAIN)
   subscriberEmail: $(LETSENCRYPT_EMAIL)
 logLevel: info
-offline: $(OFFLINE)
 ha: $(HA_ACTIVE)

--- a/dev/build/config.yml
+++ b/dev/build/config.yml
@@ -16,4 +16,5 @@ ssl:
   domain: $(LETSENCRYPT_DOMAIN)
   subscriberEmail: $(LETSENCRYPT_EMAIL)
 logLevel: info
+offline: $(OFFLINE)
 ha: $(HA_ACTIVE)


### PR DESCRIPTION
I would like to add an additional configuration switch to the docker build to enable switching to offline mode via environment variable.
If the pull request is accepted, I will add a pull request to the documentation.

Refers to #1956 