### PR TITLE
Upgrade Postgresql dependency to run in non root

### DIFF
--- a/dev/helm/Chart.lock
+++ b/dev/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://kubernetes-charts.storage.googleapis.com/
-  version: 6.5.0
-digest: sha256:e94b0117531082cb4efc287999abf5c5f7d58fecb8127251c20a7f0fc2ea65da
-generated: "2020-04-21T18:55:53.994556-07:00"
+  repository: https://charts.bitnami.com/bitnami
+  version: 8.10.14
+digest: sha256:db7c1e0bc9ec0ed45520521bd76bb390d04711fd0f04affaadafa1dc498ce68b
+generated: "2020-07-21T20:34:41.41180748-04:00"


### PR DESCRIPTION
Previous version of Postgresql required userid 0 for init container

