### PR TITLE
Align secret name

### DIFF
--- a/dev/helm/templates/_helpers.tpl
+++ b/dev/helm/templates/_helpers.tpl
@@ -70,7 +70,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- if .Values.postgresql.fullnameOverride -}}
 {{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{ printf "%s-%s" .Chart.Name "postgresql"}}
+{{ printf "%s-%s" .Release.Name "postgresql"}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
When you use a release name in the helm install command the postgresql secret name was mismatched as it uses the Chart name and not the Release name.

