### PR TITLE
Add overflow scroll to search results

### DIFF
--- a/client/components/common/search-results.vue
+++ b/client/components/common/search-results.vue
@@ -166,6 +166,7 @@ export default {
   position: fixed;
   top: 64px;
   left: 0;
+  overflow-y: scroll;
   width: 100%;
   height: calc(100% - 64px);
   background-color: rgba(0,0,0,.9);

--- a/client/components/common/search-results.vue
+++ b/client/components/common/search-results.vue
@@ -166,7 +166,7 @@ export default {
   position: fixed;
   top: 64px;
   left: 0;
-  overflow-y: scroll;
+  overflow-y: auto;
   width: 100%;
   height: calc(100% - 64px);
   background-color: rgba(0,0,0,.9);


### PR DESCRIPTION
All search results were not visible on desktop screens beyond the viewport height, adding overflow-y: scroll fixes this

![ezgif-1-671563cb08f8](https://user-images.githubusercontent.com/5248271/88507901-536c4200-cf92-11ea-8128-1af60242107e.gif)
