### PR TITLE
Fix broken contributors link in CONTRIBUTING.MD

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 First, thank you for considering contributing to Wiki.js! It's people like you that make the open source community such a great community! 😊
 
-We welcome any type of contribution, not only code. You can help with 
+We welcome any type of contribution, not only code. You can help with
 - **QA**: file bug reports, the more details you can give the better (e.g. screenshots with the console open)
 - **Marketing**: writing blog posts, howto's, printing stickers, ...
 - **Community**: presenting the project at meetups, organizing a dedicated meetup for the local community, ...
@@ -47,7 +47,7 @@ You can also reach us at hello@wikijs.opencollective.com.
 ### Contributors
 
 Thank you to all the people who have already contributed to Wiki.js!
-<a href="graphs/contributors"><img src="https://opencollective.com/wikijs/contributors.svg?width=890" /></a>
+<a href="../../graphs/contributors"><img src="https://opencollective.com/wikijs/contributors.svg?width=890" /></a>
 
 
 ### Backers

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -47,7 +47,7 @@ You can also reach us at hello@wikijs.opencollective.com.
 ### Contributors
 
 Thank you to all the people who have already contributed to Wiki.js!
-<a href="../../graphs/contributors"><img src="https://opencollective.com/wikijs/contributors.svg?width=890" /></a>
+<a href="https://github.com/Requarks/wiki/graphs/contributors"><img src="https://opencollective.com/wikijs/contributors.svg?width=890" /></a>
 
 
 ### Backers


### PR DESCRIPTION
When clicking the image under contributors in the [CONTRIBUTING.MD](https://github.com/Requarks/wiki/blob/dev/.github/CONTRIBUTING.md) file you are taken to the following link which results in a 404 https://github.com/Requarks/wiki/blob/dev/.github/graphs/contributors

This is due to the fact a relative path is used. This change replaces this with the direct link, which is consistent with the approach taken in the README.