### PR TITLE
"Search" supporting usergroup permissions by tags

### DIFF
--- a/server/graph/resolvers/page.js
+++ b/server/graph/resolvers/page.js
@@ -57,7 +57,8 @@ module.exports = {
           results: _.filter(resp.results, r => {
             return WIKI.auth.checkAccess(context.req.user, ['read:pages'], {
               path: r.path,
-              locale: r.locale
+              locale: r.locale,
+              tags: r.tags // Tags are needed since access permissions can be limited by page tags too
             })
           })
         }

--- a/server/modules/search/db/engine.js
+++ b/server/modules/search/db/engine.js
@@ -21,7 +21,11 @@ module.exports = {
    */
   async query(q, opts) {
     const results = await WIKI.models.pages.query()
-      .column('id', 'title', 'description', 'path', 'localeCode as locale')
+      .column('pages.id', 'title', 'description', 'path', 'localeCode as locale')
+      .withGraphJoined('tags') // Adding page tags since they can be used to check resource access permissions
+      .modifyGraph('tags', builder => {
+        builder.select('tag')
+      })
       .where(builder => {
         builder.where('isPublished', true)
         if (opts.locale) {


### PR DESCRIPTION
**Description**
![image](https://user-images.githubusercontent.com/886518/92729395-8caa1700-f372-11ea-99fe-ad0466a4d7d7.png)
This code will allow the "search" component to correctly filter pages by usergroup permissions based on tags instead of paths

Partially handling issue: https://github.com/Requarks/wiki/issues/2211

**Steps to reproduce the behavior**
1. Create a usegroup which can access **only** pages with the **tag** "public"
2. Create a page **without** tags or any tag except "public"
3. Create a page **with** at least the tag "public"
4. Search for the pages

If you don't have the following code you won't be able to see any result when being a part of the just created usergroup.
Otherwise you will correctly get the access to the page **with** at least the tag "public"

**Host Info (please complete the following information):**
 - OS: Docker
 - Wiki.js version: 2.5.16
 - Database engine: postgres 9.7


