### PR TITLE
Add width and height to allowed markdown attributes

### DIFF
--- a/server/modules/rendering/markdown-core/renderer.js
+++ b/server/modules/rendering/markdown-core/renderer.js
@@ -40,7 +40,7 @@ module.exports = {
     }
 
     mkdown.use(mdAttrs, {
-      allowedAttributes: ['id', 'class', 'target']
+      allowedAttributes: ['id', 'class', 'target', 'width', 'height']
     })
 
     for (let child of this.children) {


### PR DESCRIPTION
Currently if using the markdown files outside of wiki.js (In my case with pandoc) it's impossible to specify the size of an image that works in both places as the width/height attributes are stripped in wiki.js. Whilst it may be possible to do this using a class (Which is allowed), this does not allow for specific per image width/height values. 

Is there any reason that these cannot be included in the allowed attributes?

