### PR TITLE
fix: spoiler summary overflows it's parent

### DIFF
--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -801,10 +801,9 @@
       border-radius: 7px;
       background-color: mc('grey', '50');
       cursor: pointer;
-      height: 40px;
-      display: flex;
+      display: list-item;
       align-items: center;
-      padding: 0 1rem;
+      padding: 0.4rem 1rem;
       transition: background-color .4s ease;
 
       &:focus {


### PR DESCRIPTION
On mobile devices, too long summaries for spoilers overflows this spoiler in height. Managed to fix this by removing the `height` CSS property, changing the display mode to `list-item`, and adding vertical padding for `<summary>` tag.

<details><summary>Before</summary>

![](https://i.imgur.com/eGObzIA.png)
</details>
<details><summary>After</summary>

![](https://i.imgur.com/FcUJGmS.png)
</details>

P.S. Also accidentally fixed that triangle absence on Firefox.