### PR TITLE
Add a valid case for primaryEmail

### DIFF
--- a/server/models/users.js
+++ b/server/models/users.js
@@ -177,6 +177,8 @@ module.exports = class User extends Model {
     if (_.isArray(profile.emails)) {
       const e = _.find(profile.emails, ['primary', true])
       primaryEmail = (e) ? e.value : _.first(profile.emails).value
+    } else if (_.isArray(profile.email)) {
+      primaryEmail = _.first(_.flattenDeep([profile.email]));
     } else if (_.isString(profile.email) && profile.email.length > 5) {
       primaryEmail = profile.email
     } else if (_.isString(profile.mail) && profile.mail.length > 5) {


### PR DESCRIPTION
In our setup (based on yunohost) the profile.email field could be either a string (and that was properly handled) or an array.
This code adds support for the case where it is an array.

