### PR TITLE
Merge upstream changes into Matomo integration

### DIFF
--- a/server/modules/analytics/matomo/code.yml
+++ b/server/modules/analytics/matomo/code.yml
@@ -1,7 +1,7 @@
 head: |
   <!-- Matomo -->
   <script type="text/javascript">
-    var _paq = window._paq || [];
+    var _paq = window._paq = window._paq || [];
     /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
@@ -10,7 +10,7 @@ head: |
       _paq.push(['setTrackerUrl', u+'matomo.php']);
       _paq.push(['setSiteId', '{{siteId}}']);
       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.type='text/javascript'; g.async=true; g.defer=true; g.src='{{scriptUrl}}'; s.parentNode.insertBefore(g,s);
+      g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
     })();
   </script>
   <noscript><p><img src="{{serverHost}}/matomo.php?idsite={{siteId}}&amp;rec=1" style="border:0;" alt="" /></p></noscript>

--- a/server/modules/analytics/matomo/definition.yml
+++ b/server/modules/analytics/matomo/definition.yml
@@ -18,9 +18,3 @@ props:
     hint: Including https:// and optionally the port. Without trailing slash. (e.g. https://example.matomo.cloud)
     default: https://example.matomo.cloud
     order: 2
-  scriptUrl:
-    type: String
-    title: Tracking Script URL
-    hint: The full URL of the Matomo tracking script.
-    default: //cdn.matomo.cloud/EXAMPLE.matomo.cloud/matomo.js
-    order: 3


### PR DESCRIPTION
This pull request fixes #2525 by merging the upstream changes to Matomo's tracking script into the integration in WikiJS.

**Example tracking script generated by WikiJS with this PR**
```html
<!-- Matomo -->
<script type="text/javascript">
  var _paq = window._paq = window._paq || [];
  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
  _paq.push(['trackPageView']);
  _paq.push(['enableLinkTracking']);
  (function() {
    var u="https://matomo.datahoarder.dev/";
    _paq.push(['setTrackerUrl', u+'matomo.php']);
    _paq.push(['setSiteId', '2']);
    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
  })();
</script>
<noscript><p><img src="https://matomo.datahoarder.dev/matomo.php?idsite=2&amp;rec=1" style="border:0;" alt="" /></p></noscript>
<!-- End Matomo Code -->
```

**Example tracking script generated by Matomo**
```html
<!-- Matomo -->
<script type="text/javascript">
  var _paq = window._paq = window._paq || [];
  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
  _paq.push(['trackPageView']);
  _paq.push(['enableLinkTracking']);
  (function() {
    var u="https://matomo.datahoarder.dev/";
    _paq.push(['setTrackerUrl', u+'matomo.php']);
    _paq.push(['setSiteId', '2']);
    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
  })();
</script>
<!-- End Matomo Code -->
```

Visits via Tor Browser (no Javascript) and via VPN (with JavaScript) are being successfully logged in Matomo with this PR.

![matomo](https://xbb.datahoarder.dev/VUSu3/sUSIZIRu63.png/raw)