### PR TITLE
bugfix: Fix var name

### DIFF
--- a/client/components/comments.vue
+++ b/client/components/comments.vue
@@ -109,7 +109,7 @@
                   outlined
                   )
                   v-icon(left) mdi-close
-                  span.text-none {{$t('common:action.cancel')}}
+                  span.text-none {{$t('common:actions.cancel')}}
                 v-btn(
                   dark
                   color='blue-grey darken-2'


### PR DESCRIPTION
The i18n var `common:action.cancel` is correctly `common:action*s*.cancel`.
ref: https://github.com/Requarks/wiki-localization/search?q=common:actions.cancel