### PR TITLE
Enable passport-azure-ad workaround for SameSite cookies

### DIFF
--- a/server/modules/authentication/azure/authentication.js
+++ b/server/modules/authentication/azure/authentication.js
@@ -10,6 +10,19 @@ const OIDCStrategy = require('passport-azure-ad').OIDCStrategy
 
 module.exports = {
   init (passport, conf) {
+    // Workaround for Chrome's SameSite cookies
+    // cookieSameSite needs useCookieInsteadOfSession to work correctly.
+    // cookieEncryptionKeys is extracted from conf.cookieEncryptionKeyString.
+    // It's a concatnation of 44-character length strings each of which represents a single pair of key/iv.
+    // Valid cookieEncryptionKeys enables both cookieSameSite and useCookieInsteadOfSession.
+    const keyArray = [];
+    if (conf.cookieEncryptionKeyString) {
+      let keyString = conf.cookieEncryptionKeyString;
+      while (keyString.length >= 44) {
+        keyArray.push({ key: keyString.substring(0, 32), iv: keyString.substring(32, 44) });
+        keyString = keyString.substring(44);
+      }
+    }
     passport.use('azure',
       new OIDCStrategy({
         identityMetadata: conf.entryPoint,
@@ -19,7 +32,10 @@ module.exports = {
         responseMode: 'form_post',
         scope: ['profile', 'email', 'openid'],
         allowHttpForRedirectUrl: WIKI.IS_DEBUG,
-        passReqToCallback: true
+        passReqToCallback: true,
+        cookieSameSite: keyArray.length > 0,
+        useCookieInsteadOfSession: keyArray.length > 0,
+        cookieEncryptionKeys: keyArray
       }, async (req, iss, sub, profile, cb) => {
         const usrEmail = _.get(profile, '_json.email', null) || _.get(profile, '_json.preferred_username')
         try {

--- a/server/modules/authentication/azure/definition.yml
+++ b/server/modules/authentication/azure/definition.yml
@@ -22,4 +22,8 @@ props:
     title: Client ID
     hint: The client ID of your application in AAD (Azure Active Directory)
     order: 2
-
+  cookieEncryptionKeyString:
+    type: String
+    title: Cookie Encryption Key String
+    hint: Random string with 44-character length.  Setting this enables workaround for Chrome's SameSite cookies.
+    order: 3


### PR DESCRIPTION
This adds cookieEncryptionKeyString configuration in the Azure AD authentication module.  It represents an array of cookie encryption strings and enables workaround for SameSite cookies.

See [the passport-azure-ad doc](https://github.com/AzureAD/passport-azure-ad#41-oidcstrategy) about new `OIDCStrategy` options: `cookieSameSite`, `useCookieInsteadOfSession`, `cookieEncryptionKeys`.  It's not mentioned in the doc that `cookieSameSite` won't work without `useCookieInsteadOfSession` or without `cookieEncryptionKeys`.

When enabled, it returns a short-lived cookie with `Secure; SameSite=None` during Azure AD OpenID Connect authentication attempts.

![image](https://user-images.githubusercontent.com/106724/95673199-a644b580-0be1-11eb-9eeb-247fa8e5eb3b.png)

Unfortunately there's no unit test because I'm not familiar with auth module testing.  And it's missing the way to add this to existing Azure AD authentication configurations (direct fixes on DB?).

This may fix the problem #2544, #1992