### PR TITLE
Fix minor misspelling in Subscript/Superscript rendering module

### DIFF
--- a/server/modules/rendering/markdown-supsub/definition.yml
+++ b/server/modules/rendering/markdown-supsub/definition.yml
@@ -13,6 +13,6 @@ props:
     default: true
   supEnabled:
     type: Boolean
-    title: Supercript
-    hint: Enable supercript tags
+    title: Superscript
+    hint: Enable superscript tags
     default: true


### PR DESCRIPTION
Fix spelling of superscript in definition file for subscript/superscript rendering module. ("supercript" -> "superscript")

