### PR TITLE
Add quotation mark to metadata injection to avoid YAML parse exception.

### DIFF
--- a/server/helpers/page.js
+++ b/server/helpers/page.js
@@ -73,8 +73,8 @@ module.exports = {
    */
   injectPageMetadata(page) {
     let meta = [
-      ['title', page.title],
-      ['description', page.description],
+      ['title', '"' + page.title + '"'],
+      ['description', '"' + page.description + '"'],
       ['published', page.isPublished.toString()],
       ['date', page.updatedAt],
       ['tags', page.tags ? page.tags.map(t => t.tag).join(', ') : ''],


### PR DESCRIPTION
Quoting & unquoting page.title and page.description for YAML metadata is required for avoiding parse exception when page.title or page.description contains special letters (emojis, CJK letters, etc.). Otherwise, it will cause an error when importing the .md file to Wiki.js' database.