### PR TITLE
fix: media print css

### DIFF
--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -966,13 +966,13 @@
     }
   }
 
-  .v-content {
+  .v-main {
     padding: 0 !important;
     font-size: 14px;
     background-color: #FFF;
   }
 
-  .v-content .contents {
+  .v-main .contents {
     color: #000;
     background-color: #FFF;
 


### PR DESCRIPTION
This fixes code block text issue in printed pdf.
text-shadow cause duplicate letter in pdf. (fix #2590)

**Screenshot (Before)**
<img width="412" alt="before" src="https://user-images.githubusercontent.com/18533151/96332542-7f81f580-109f-11eb-877c-854d2b16f76b.png">

**Screenshot (After)**
<img width="398" alt="after" src="https://user-images.githubusercontent.com/18533151/96332546-8872c700-109f-11eb-8891-0a3ac7dbaecb.png">
