### PR TITLE
fix: use absolute URL for logo in email

### DIFF
--- a/server/core/mail.js
+++ b/server/core/mail.js
@@ -56,7 +56,7 @@ module.exports = {
       subject: `${opts.subject} - ${WIKI.config.title}`,
       text: opts.text,
       html: _.get(this.templates, opts.template)({
-        logo: WIKI.config.logoUrl,
+        logo: (WIKI.config.logoUrl.startsWith('http') ? '' : WIKI.config.host) + WIKI.config.logoUrl,
         siteTitle: WIKI.config.title,
         copyright: WIKI.config.company.length > 0 ? WIKI.config.company : 'Powered by Wiki.js',
         ...opts.data


### PR DESCRIPTION
Prepends the wiki site URL to the logo path used when sending email from the wiki.

Before: `<img src="/uploads/logo.png"`
After: `<img src="http://wiki.site.url/uploads/logo.png`