### PR TITLE
Set autocommit for mysql

### DIFF
--- a/server/core/db.js
+++ b/server/core/db.js
@@ -140,6 +140,10 @@ module.exports = {
               await conn.query(`set application_name = 'Wiki.js'`)
               done()
               break
+            case 'mysql':
+              await conn.promise().query(`set autocommit = 1`)
+              done()
+              break
             default:
               done()
               break


### PR DESCRIPTION
If in server config mysql has autocommit = 0, then wikijs fails with locks like this:
```
2020-10-30T12:56:51.725Z [JOB] error: Rebuilding page tree: [ FAILED ]
2020-10-30T12:56:51.726Z [JOB] error: truncate `pageTree` - Lock wait timeout exceeded; try restarting transaction
```

