### PR TITLE
fix: inline math interpreted as attributes

### DIFF
--- a/client/components/editor/common/katex.js
+++ b/client/components/editor/common/katex.js
@@ -81,7 +81,14 @@ export default {
     if (!silent) {
       token = state.push('katex_inline', 'math', 0)
       token.markup = '$'
-      token.content = state.src.slice(start, match)
+      token.content = state.src
+        // Extract the math part without the $
+        .slice(start, match)
+        // Escape the curly braces since they will be interpreted as
+        // attributes by markdown-it-attrs (the "curly_attributes"
+        // core rule)
+        .replaceAll("{", "{{")
+        .replaceAll("}", "}}")
     }
 
     state.pos = match + 1


### PR DESCRIPTION
When using inline math (`$e^{-x^2}$`) the curly braces are interpreted as attributes by [markdown-it-attrs](https://github.com/arve0/markdown-it-attrs). Since most of the times they are not valid attributes they simply get removed.

This patch escapes the curly braces (the default attribute delimiter), fixing the KaTeX rendering errors.

The problem occurs only when the inline math ends with a _curly brace block_ (see examples below). For this reason the third example below works also in the current version.
An alternative fix may have been to force the math block not to end with the curly braces, for example by adding some spacing (e.g. `\,`). I preferred not adding some spurious spaces, the escaping strategy should be pretty invisible.

One could think it should be enough to escape the last `{` and `}`, in practice it's not enough: `$e^{e^{x}+1}$` would become `$e^{e^{{x}+1}}$`, which is valid but clearly not equivalent. (note that this example is not broken in the current version since the last _curly block_ contains another _curly block_, which apparently it's fine).

It would be nice to simply skip that rule for `katex_inline` block types but as far as I know markdown-it-attrs doesn't have such an [option](https://github.com/arve0/markdown-it-attrs/blob/3254c2bb5f091a7680e8ac86ce62dd4561fb8e89/patterns.js#L306).

---

### Example
```
$e^{-x^2}$

$P_{static} = I_{DD}V_{DD}$

$V_{DD}=5V$
```

### Previously
![image](https://user-images.githubusercontent.com/6685454/97783442-1c608a80-1b98-11eb-8412-a2918afeec23.png)


```
ParseError: KaTeX parse error: Expected group after '^' at position 2: e^̲
ParseError: KaTeX parse error: Expected group after '_' at position 21: …atic} = I_{DD}V_̲
```

### Now
![image](https://user-images.githubusercontent.com/6685454/97783435-0d79d800-1b98-11eb-9bde-65a635f09363.png)

------

Fixes #1581 