### PR TITLE
Support tags containing special characters

### DIFF
--- a/client/components/tags.vue
+++ b/client/components/tags.vue
@@ -243,7 +243,7 @@ export default {
   router,
   created () {
     this.$store.commit('page/SET_MODE', 'tags')
-    this.selection = _.compact(this.$route.path.split('/'))
+    this.selection = _.compact(decodeURI(this.$route.path).split('/'))
   },
   mounted () {
     this.locales = _.concat(


### PR DESCRIPTION
See #2743

### Manual tests

Initial state : Create a "Home" page having two tags "hé hé hé" and "hello world". Navigate to view that page.

- [x] When clicking on "hé hé hé", then it preselects the matching tag and displays "Home" among the results
- [x] When clicking on "hé hé hé", and refreshing the page, then it returns identical results
- [x] When clicking on "hé hé hé", and interacting with tags on the sidebar, then it updates the search results and address bar expectedly
- [x] When going to the tags page, and clicking both tags "hé hé hé" and "hello world", and refreshing the page, then it still returns "Home" among the results