### PR TITLE
Changes for interactive plantuml

### DIFF
--- a/server/modules/rendering/html-security/renderer.js
+++ b/server/modules/rendering/html-security/renderer.js
@@ -32,6 +32,59 @@ module.exports = {
         allowedAttrs.push('allow')
       }
 
+      //Changes to keep interactive plantuml object tag
+
+      //only allow specific attributes for plantuml object node
+      allowedTags.push('object')
+      allowedAttrs.push('data')
+      allowedAttrs.push('type')
+      allowedAttrs.push('style')
+      allowedAttrs.push('class')
+      allowedAttrs.push('alt')
+
+      DOMPurify.addHook('uponSanitizeElement',  (node, data) => {
+        // keep object node only if it is
+        // authorised plantuml using the configured plantuml server
+        // force attribute values to configured params
+        // insert the plantuml inside the object as text for search
+        let isPumlNode=false
+
+        if (data.tagName === 'object') {
+          //console.log ("Found object node - validating")
+          //remove node if it doesn't conform to plantuml structure
+          if (!( 'data' in node.attributes
+                && 'class' in node.attributes
+                && 'style' in node.attributes
+                && 'type' in node.attributes
+                && 'alt' in node.attributes)
+          ) {
+            //console.log ("Attribute mismatch - removing object node")
+            return node.parentNode.removeChild(node)
+          }
+
+          dataAttribute = node.getAttribute ('data')
+
+          //only allow configured plantuml server and image format in url
+          if (dataAttribute
+              && dataAttribute.startsWith(`${pumlServer}/${pumlImageFormat}`)
+          ) {
+            //console.log ("Plantuml node found - setting atribute values")
+            isPumlNode=true
+            node.setAttribute ('type', `${pumlObjectType}`)
+            node.setAttribute ('style', `${pumlObjectStyle}`)
+            node.setAttribute ('class', `${pumlObjectClass}`)
+            node.setAttribute ('alt', '')
+          }
+
+          //if not a plantuml node, then sanitise it
+          if (!isPumlNode) {
+            console.log ("Removing unknown object node")
+            return node.parentNode.removeChild(node)
+          }
+        }
+      })
+      //End changes to keep interactive plantuml object tag
+
       input = DOMPurify.sanitize(input, {
         ADD_ATTR: allowedAttrs,
         ADD_TAGS: allowedTags

--- a/server/modules/rendering/markdown-plantuml/renderer.js
+++ b/server/modules/rendering/markdown-plantuml/renderer.js
@@ -114,14 +114,74 @@ module.exports = {
 
         const zippedCode = encode64(zlib.deflateRawSync('@startuml\n' + contents + '\n@enduml').toString('binary'))
 
-        token = state.push('uml_diagram', 'img', 0)
-        // alt is constructed from children. No point in populating it here.
-        token.attrs = [ [ 'src', `${server}/${imageFormat}/${zippedCode}` ], [ 'alt', '' ], ['class', 'uml-diagram prefetch-candidate'] ]
-        token.block = true
-        token.children = altToken
-        token.info = params
-        token.map = [ startLine, nextLine ]
-        token.markup = markup
+        //Interactive plantuml changes start here
+
+        //Global variables that will be used in html-security
+        pumlImageFormat = imageFormat
+        pumlServer = server
+        pumlObjectType = 'image/svg+xml'
+        pumlObjectStyle = 'max-width:100%;height:auto'
+        pumlObjectClass = 'uml-diagram prefetch-candidate'
+
+        if (imageFormat === 'png') {
+          //non-interactive and not searchable - use the img tag
+          token = state.push('uml_diagram', 'img', 0)
+          // alt is constructed from children. No point in populating it here.
+          token.attrs = [ [ 'src' , `${server}/${imageFormat}/${zippedCode}` ],
+                          [ 'alt' , '' ],
+                          ['class', `${pumlObjectClass}` ]
+                        ]
+          token.block = true
+          token.children = altToken
+          token.info = params
+          token.map = [ startLine, nextLine ]
+          token.markup = markup
+        }
+        else if (imageFormat === 'svg') {
+          // render svg interactively with object tag
+          /* <object data=<plantumlserver>/<format>/plantuml
+                alt='' class='uml-diagram prefetch-candidate'
+                style='max-width:100%;height:auto' type='image/svg+xml' > */
+          token = state.push('uml_diagram_obj', 'object', 0)
+          token.attrs = [ [ 'data' , `${server}/${imageFormat}/${zippedCode}`],
+                          [ 'alt'  ,  '' ],
+                          [ 'class', `${pumlObjectClass}` ],
+                          [ 'style', `${pumlObjectStyle}` ],
+                          [ 'type',  `${pumlObjectType}`  ]
+                        ]
+          token.block = true
+          token.children = altToken
+          token.info = params
+          token.map = [ startLine, nextLine ]
+          token.markup = markup
+
+          //backup img node for object render failure
+          //void element - doesn't need to be closed in html
+          /* <img src=data=<plantumlserver>/<format>/plantuml alt=''
+                  class='uml-diagram prefetch-candidate'
+                  type='image/svg+xml'> */
+          token = state.push('uml_diagram_img', 'img', 0)
+          // alt is constructed from children. No point in populating it here.
+          token.attrs = [ [ 'src' , `${server}/${imageFormat}/${zippedCode}` ],
+                          [ 'alt' , '' ],
+                          ['class', `${pumlObjectClass}`]
+                        ]
+          token.block = true
+          token.children = altToken
+          token.info = params
+          token.map = [ startLine, nextLine ]
+          token.markup = markup
+
+          //add puml source in object node for wikijs search index
+          //as wikijs will not index svg content from object tag
+          //i.e. like <object ...>@startuml...@enduml</object>
+          token = state.push ('text', '', 0)
+          token.content = contents
+
+          //close object tag - </object>
+          token = state.push('uml_diagram_close', 'object', -1)
+        }
+        //Interactive plantuml changes end here
 
         state.line = nextLine + (autoClosed ? 1 : 0)
 


### PR DESCRIPTION
This is a copy of the original pull request [here](https://github.com/Requarks/wiki/pull/1337) 

Creating this pull request on dev branch as discussed with @NGPixel . I had originally created this a while ago by forking the  master branch and hence needed to rewrite this using DOMPurify.

Summary:
Plantuml is currently created as an image which means that links do not work and the plantuml content is treated as a picture and is not searchable

This PR does the following:
- Renders plantuml as svg using `object` tag so that it is interactive and selectable (e.g. you can now copy paste text from within the  diagram) with a backup non-interactive img tag if browser will not render `object`
- Places the original plantuml content inline inside the object tag to ensure that this is not visible but included in wikijs search index

As `object` tag is typically insecure, it is checked and sanitised to make sure that 
- Only the configured plantuml server, image format (e.g. https://plantuml.requarks.io/svg/<encoded plantuml>) are allowed in the url parameter passed in `data`; Any other value results in the node being discarded
- Only attributes required for plantuml+wikijs are allowed (`style`/`class`/`type`/`data`/`alt`); mismatch in number of attributes being passed in will result in the node being discarded. 
- Allowed attributes  other than `data` are overriden to the required values for plantuml to work with wikijs explicitly to avoid any code injection scenarios

Tested using [sample markdown](https://github.com/Requarks/wiki/files/4005764/Test-Plantuml.txt)
