### PR TITLE
Feature: Custom configuration for elasticsearch

### DIFF
--- a/server/modules/search/elasticsearch/definition.yml
+++ b/server/modules/search/elasticsearch/definition.yml
@@ -26,16 +26,22 @@ props:
     hint: The index name to use during creation
     default: wiki
     order: 3
+  analyzer:
+    type: String
+    title: Analyzer
+    hint: 'The token analyzer in elasticsearch'
+    default: simple
+    order: 4
   sniffOnStart:
     type: Boolean
     title: Sniff on start
     hint: 'Should Wiki.js attempt to detect the rest of the cluster on first connect? (Default: off)'
     default: false
-    order: 4
+    order: 5
   sniffInterval:
     type: Number
     title: Sniff Interval
     hint: '0 = disabled, Interval in seconds to check for updated list of nodes in cluster. (Default: 0)'
     default: 0
-    order: 5
+    order: 6
 

--- a/server/modules/search/elasticsearch/engine.js
+++ b/server/modules/search/elasticsearch/engine.js
@@ -57,12 +57,12 @@ module.exports = {
           const idxBody = {
             properties: {
               suggest: { type: 'completion' },
-              title: { type: 'text', boost: 10.0 },
-              description: { type: 'text', boost: 3.0 },
-              content: { type: 'text', boost: 1.0 },
+              title: { type: 'text', boost: 10.0, analyzer: this.config.analyzer },
+              description: { type: 'text', boost: 3.0, analyzer: this.config.analyzer },
+              content: { type: 'text', boost: 1.0, analyzer: this.config.analyzer },
               locale: { type: 'keyword' },
               path: { type: 'text' },
-              tags: { type: 'text', boost: 8.0 }
+              tags: { type: 'text', boost: 8.0, analyzer: this.config.analyzer }
             }
           }
           await this.client.indices.create({

--- a/server/modules/search/elasticsearch/engine.js
+++ b/server/modules/search/elasticsearch/engine.js
@@ -63,7 +63,7 @@ module.exports = {
               locale: { type: 'keyword' },
               path: { type: 'text' },
               tags: { type: 'text', boost: 8.0 }
-            },
+            }
           }
           await this.client.indices.create({
             index: this.config.indexName,

--- a/server/modules/search/elasticsearch/engine.js
+++ b/server/modules/search/elasticsearch/engine.js
@@ -57,20 +57,29 @@ module.exports = {
           const idxBody = {
             properties: {
               suggest: { type: 'completion' },
-              title: { type: 'text', boost: 10.0, analyzer: this.config.analyzer },
-              description: { type: 'text', boost: 3.0, analyzer: this.config.analyzer },
-              content: { type: 'text', boost: 1.0, analyzer: this.config.analyzer },
+              title: { type: 'text', boost: 10.0 },
+              description: { type: 'text', boost: 3.0 },
+              content: { type: 'text', boost: 1.0 },
               locale: { type: 'keyword' },
               path: { type: 'text' },
-              tags: { type: 'text', boost: 8.0, analyzer: this.config.analyzer }
-            }
+              tags: { type: 'text', boost: 8.0 }
+            },
           }
           await this.client.indices.create({
             index: this.config.indexName,
             body: {
               mappings: (this.config.apiVersion === '6.x') ? {
                 _doc: idxBody
-              } : idxBody
+              } : idxBody,
+              settings: {
+                analysis: {
+                  analyzer: {
+                    default: {
+                      type: this.config.analyzer
+                    }
+                  }
+                }
+              }
             }
           })
         } catch (err) {


### PR DESCRIPTION
For better search results especially in Chinese, which the standard token analyzer may not work well. In Chinese, the adminstrator may need to set the token analyzer to smartcn, itk, etc. This PR adds the elastic analyzer configuration to the search module.

