### PR TITLE
Fix: Search engine broken when renaming or moving pages

### DIFF
--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -544,6 +544,8 @@ module.exports = class Page extends Model {
     await WIKI.models.pages.rebuildTree()
 
     // -> Rename in Search Index
+    const pageContents = await WIKI.models.pages.query().findById(page.id).select('render')
+    page.safeContent = WIKI.models.pages.cleanHTML(pageContents.render)
     await WIKI.data.searchEngine.renamed({
       ...page,
       destinationPath: opts.destinationPath,


### PR DESCRIPTION
For building suggest in elasticsearch, the safeContent field will be splitted into arrays. If the page is renamed or moved, the server will throw error: "Cannot read property 'split' of Undefined", and the index will be broken. Here two lines are added to fix this issue.

