### PR TITLE
Fix: In group edit rules, write scripts permission and write styles permission can be configured.

### DIFF
--- a/client/components/admin/admin-groups-edit-rules.vue
+++ b/client/components/admin/admin-groups-edit-rules.vue
@@ -222,6 +222,8 @@ export default {
         { text: 'Read / Use Assets', value: 'read:assets', icon: 'mdi-image-search-outline' },
         { text: 'Upload Assets', value: 'write:assets', icon: 'mdi-image-plus' },
         { text: 'Edit + Delete Assets', value: 'manage:assets', icon: 'mdi-image-size-select-large' },
+        { text: 'Edit Scripts', value: 'write:scripts', icon: 'mdi-language-javascript' },
+        { text: 'Edit Styles', value: 'write:styles', icon: 'mdi-language-css3' },
         { text: 'Read Comments', value: 'read:comments', icon: 'mdi-comment-search-outline' },
         { text: 'Create Comments', value: 'write:comments', icon: 'mdi-comment-plus-outline' },
         { text: 'Edit + Delete Comments', value: 'manage:comments', icon: 'mdi-comment-remove-outline' }


### PR DESCRIPTION
Fix: In group edit rules, write scripts permission and write styles permission can be configured.

At present, the user that are not in the administrator group have no access to edit scripts and styles in page editor panel. This commit add configuration in group rule manage webpage so that users' permission on writing styles and writing scripts can be modified.

