### PR TITLE
Fix: Rebuilding tree error when the page number is large enough in sqlite

### DIFF
--- a/server/jobs/rebuild-tree.js
+++ b/server/jobs/rebuild-tree.js
@@ -57,8 +57,14 @@ module.exports = async (pageId) => {
     await WIKI.models.knex.table('pageTree').truncate()
     if (tree.length > 0) {
       // -> Save in chunks, because of per query max parameters (35k Postgres, 2k MSSQL, 1k for SQLite)
-      for (const chunk of _.chunk(tree, 100)) {
-        await WIKI.models.knex.table('pageTree').insert(chunk)
+      if ((WIKI.config.db.type !== 'sqlite'))
+        for (const chunk of _.chunk(tree, 100)) {
+          await WIKI.models.knex.table('pageTree').insert(chunk)
+        }
+      } else {
+        for (const chunk of _.chunk(tree, 60)) {
+          await WIKI.models.knex.table('pageTree').insert(chunk)
+        }
       }
     }
 


### PR DESCRIPTION
See https://github.com/Requarks/wiki/issues/1503 and https://github.com/Requarks/wiki/issues/2553

When the total page number is large enough (usually about 80+), sqlite will throw error: "Too many variables". This commit reduces the chunk size for sqlite configuration.

