### PR TITLE
Update storage.js to match pageHelper.injectPageMetadata

### DIFF
--- a/server/modules/storage/disk/storage.js
+++ b/server/modules/storage/disk/storage.js
@@ -127,7 +127,7 @@ module.exports = {
 
     // -> Pages
     await pipeline(
-      WIKI.models.knex.column('path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt', 'createdAt', 'editorKey').select().from('pages').where({
+      WIKI.models.knex.column('id', 'path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt', 'createdAt', 'editorKey').select().from('pages').where({
         isPrivate: false
       }).stream(),
       new stream.Transform({

--- a/server/modules/storage/disk/storage.js
+++ b/server/modules/storage/disk/storage.js
@@ -127,12 +127,15 @@ module.exports = {
 
     // -> Pages
     await pipeline(
-      WIKI.models.knex.column('path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt', 'createdAt').select().from('pages').where({
+      WIKI.models.knex.column('path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt', 'createdAt', 'editorKey').select().from('pages').where({
         isPrivate: false
       }).stream(),
       new stream.Transform({
         objectMode: true,
         transform: async (page, enc, cb) => {
+          const pageObject = await WIKI.models.pages.query().findById(page.id)
+          page.tags = await pageObject.$relatedQuery('tags')
+          
           let fileName = `${page.path}.${pageHelper.getFileExtension(page.contentType)}`
           if (WIKI.config.lang.code !== page.localeCode) {
             fileName = `${page.localeCode}/${fileName}`

--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -411,12 +411,15 @@ module.exports = {
 
     // -> Pages
     await pipeline(
-      WIKI.models.knex.column('path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt', 'createdAt').select().from('pages').where({
+      WIKI.models.knex.column('id', 'path', 'localeCode', 'title', 'description', 'contentType', 'content', 'isPublished', 'updatedAt', 'createdAt', 'editorKey').select().from('pages').where({
         isPrivate: false
       }).stream(),
       new stream.Transform({
         objectMode: true,
         transform: async (page, enc, cb) => {
+          const pageObject = await WIKI.models.pages.query().findById(page.id)
+          page.tags = await pageObject.$relatedQuery('tags')
+          
           let fileName = `${page.path}.${pageHelper.getFileExtension(page.contentType)}`
           if (WIKI.config.lang.namespacing && WIKI.config.lang.code !== page.localeCode) {
             fileName = `${page.localeCode}/${fileName}`


### PR DESCRIPTION
At `pageHelper.injectPageMetadata` references `editorKey` and `tags` to build metadata, but this data seems not to be supplied to this function, since page object is only built from specified columns.

As a result, tags are always empty when exporting pages, and editor key appears as undefined.

<img width="385" alt="Captura de pantalla 2020-12-17 a las 2 58 38" src="https://user-images.githubusercontent.com/17545750/102432985-c5adf380-4013-11eb-9c1c-efb7c0a9fdec.png">

It happens also with git storage, but it may also happen with another storage providers.

I run into this issue running Wiki.js 2.5.170 with the following Docker stack:

```
CONTAINER ID        IMAGE                                   COMMAND                  CREATED             STATUS              PORTS                                         NAMES
39373979b693        requarks/wiki:2                         "docker-entrypoint.s…"   44 minutes ago      Up 9 minutes        0.0.0.0:80->3000/tcp, 0.0.0.0:443->3443/tcp   wiki
608de6278aaa        requarks/wiki-update-companion:latest   "dotnet wiki-update-…"   5 months ago        Up 6 hours          80/tcp                                        wiki-update-companion
12c7b35ba295        postgres:11                             "docker-entrypoint.s…"   5 months ago        Up 6 hours          5432/tcp                                      db
```
