### PR TITLE
Change "Site Tree" navigation to redirect to folder landing pages

### DIFF
--- a/client/themes/default/components/nav-sidebar.vue
+++ b/client/themes/default/components/nav-sidebar.vue
@@ -46,18 +46,14 @@
     //-> Browse
     v-list.py-2(v-else-if='currentMode === `browse`', dense, :class='color', :dark='dark')
       template(v-if='currentParent.id > 0')
-        v-list-item(v-for='(item, idx) of parents', :key='`parent-` + item.id', @click='fetchBrowseItems(item)', style='min-height: 30px;')
+        v-list-item(v-for='(item, idx) of parents', :key='`parent-` + item.id', @click='routeNavLink(item)', style='min-height: 30px;', :input-value='path === item.path')
           v-list-item-avatar(size='18', :style='`padding-left: ` + (idx * 8) + `px; width: auto; margin: 0 5px 0 0;`')
             v-icon(small) mdi-folder-open
           v-list-item-title {{ item.title }}
         v-divider.mt-2
-        v-list-item.mt-2(v-if='currentParent.pageId > 0', :href='`/` + currentParent.path', :key='`directorypage-` + currentParent.id', :input-value='path === currentParent.path')
-          v-list-item-avatar(size='24')
-            v-icon mdi-text-box
-          v-list-item-title {{ currentParent.title }}
-        v-subheader.pl-4 {{$t('common:sidebar.currentDirectory')}}
+        v-subheader.pl-4(v-if='currentItems.length') {{$t('common:sidebar.currentDirectory')}}
       template(v-for='item of currentItems')
-        v-list-item(v-if='item.isFolder', :key='`childfolder-` + item.id', @click='fetchBrowseItems(item)')
+        v-list-item(v-if='item.isFolder', :key='`childfolder-` + item.id', @click='routeNavLink(item)', :input-value='path === item.path')
           v-list-item-avatar(size='24')
             v-icon mdi-folder
           v-list-item-title {{ item.title }}
@@ -117,6 +113,15 @@ export default {
         this.loadFromCurrentPath()
       }
     },
+
+    async routeNavLink(item) {
+      if (item.pageId === null) {
+        return this.fetchBrowseItems(item)
+      } else {
+        window.location.href = '/' + item.locale + '/' + item.path
+      }
+    },
+
     async fetchBrowseItems (item) {
       this.$store.commit(`loadingStart`, 'browse-load')
       if (!item) {
@@ -166,6 +171,7 @@ export default {
       })
       this.loadedCache = _.union(this.loadedCache, [item.id])
       this.currentItems = _.get(resp, 'data.pages.tree', [])
+
       this.$store.commit(`loadingStop`, 'browse-load')
     },
     async loadFromCurrentPath() {
@@ -206,6 +212,7 @@ export default {
         if (!curParent) {
           break
         }
+
         invertedAncestors.push(curParent)
         curParentId = curParent.parent
       }
@@ -216,6 +223,10 @@ export default {
       this.loadedCache = [curPage.parent]
       this.currentItems = _.filter(items, ['parent', curPage.parent])
       this.$store.commit(`loadingStop`, 'browse-load')
+
+      if (curPage.isFolder) {
+        this.fetchBrowseItems(curPage)
+      }
     },
     goHome () {
       window.location.assign(siteLangs.length > 0 ? `/${this.locale}/home` : '/')

--- a/client/themes/default/components/nav-sidebar.vue
+++ b/client/themes/default/components/nav-sidebar.vue
@@ -48,7 +48,8 @@
       template(v-if='currentParent.id > 0')
         v-list-item(v-for='(item, idx) of parents', :key='`parent-` + item.id', @click='routeNavLink(item)', style='min-height: 30px;', :input-value='path === item.path')
           v-list-item-avatar(size='18', :style='`padding-left: ` + (idx * 8) + `px; width: auto; margin: 0 5px 0 0;`')
-            v-icon(small) mdi-folder-open
+            v-icon(v-if='item.id === 0' small) mdi-home
+            v-icon(v-else small) mdi-folder-open
           v-list-item-title {{ item.title }}
         v-divider.mt-2
         v-subheader.pl-4(v-if='currentItems.length') {{$t('common:sidebar.currentDirectory')}}
@@ -95,7 +96,7 @@ export default {
       currentItems: [],
       currentParent: {
         id: 0,
-        title: '/ (root)'
+        title: 'Home'
       },
       parents: [],
       loadedCache: []
@@ -117,6 +118,8 @@ export default {
     async routeNavLink(item) {
       if (item.pageId === null) {
         return this.fetchBrowseItems(item)
+      } else if (item.id === 0) {
+        return this.goHome()
       } else {
         window.location.href = '/' + item.locale + '/' + item.path
       }
@@ -218,6 +221,11 @@ export default {
       }
 
       this.parents = [this.currentParent, ...invertedAncestors.reverse()]
+
+      if (this.currentParent.id === 0) {
+        this.currentParent.title = 'Home'
+      }
+
       this.currentParent = _.last(this.parents)
 
       this.loadedCache = [curPage.parent]


### PR DESCRIPTION
After deploying Wiki.js in our company, we had a lot of feedback from confused users when using the "Site Tree" navigation. This revealed to be due to a couple of interaction facts:

* Clicking on a folder would not take you to the landing page of that folder, requiring a second click on the landing page to reach the information.
* Clicking on the landing page would take the navigation back to the level above the landing page folder, making it impossible to read the landing page while seeing the sub-pages of that folder in the nav.

We have explored the other types of navigation but the ability for the "Site Tree" to dynamically display sub-pages was just too valuable. As a result, we decided to patch it by making sure that **clicking on a folder would redirect you to that folder's landing page**. We also modified the tree to represent the home page as the root and added a redirect to it.

We have no hope or desire to see this request merged in its current state since we are aware of the patched nature of the change. That being said, we thought this could be a great platform to discuss the validity of the feature and the way you'd see it implemented. We obviously would like to avoid having to maintain a fork and are ready to put in the necessary work.

Thank you.