### PR TITLE
fix: LDAP: avoid reading empty tls cert file

### DIFF
--- a/server/modules/authentication/ldap/authentication.js
+++ b/server/modules/authentication/ldap/authentication.js
@@ -18,12 +18,7 @@ module.exports = {
           bindCredentials: conf.bindCredentials,
           searchBase: conf.searchBase,
           searchFilter: conf.searchFilter,
-          tlsOptions: (conf.tlsEnabled) ? {
-            rejectUnauthorized: conf.verifyTLSCertificate,
-            ca: [
-              fs.readFileSync(conf.tlsCertPath)
-            ]
-          } : {},
+          tlsOptions: getTlsOptions(conf),
           includeRaw: true
         },
         usernameField: 'email',
@@ -54,5 +49,27 @@ module.exports = {
         }
       }
       ))
+  }
+}
+
+function getTlsOptions(conf) {
+  if (!conf.tlsEnabled) {
+    return {}
+  }
+
+  if (!conf.tlsCertPath) {
+    return {
+      rejectUnauthorized: conf.verifyTLSCertificate,
+    }
+  }
+
+  const caList = []
+  if (conf.verifyTLSCertificate) {
+    caList.push(fs.readFileSync(conf.tlsCertPath))
+  }
+
+  return {
+    rejectUnauthorized: conf.verifyTLSCertificate,
+    ca: caList
   }
 }


### PR DESCRIPTION
Fixes #2624

We avoid reading the `tlsCertPath` property if it is not needed. 

`tlsEnabled`: true, `verifyTLSCertificate`: true => read `tlsCertPath`
`tlsEnabled`: true, `verifyTLSCertificate`: true, `tlsCertPath`: `''` => __do not__ `fs.readFileSync(conf.tlsCertPath)`
`tlsEnabled`: true, `verifyTLSCertificate`: false => __do not__ `fs.readFileSync(conf.tlsCertPath)`
`tlsEnabled`: false `verifyTLSCertificate`: false => __do not__ `fs.readFileSync(conf.tlsCertPath)`