### PR TITLE
fix: get syncInterval from model not module data

### DIFF
--- a/server/graph/resolvers/storage.js
+++ b/server/graph/resolvers/storage.js
@@ -19,7 +19,7 @@ module.exports = {
           ...targetInfo,
           ...tgt,
           hasSchedule: (targetInfo.schedule !== false),
-          syncInterval: targetInfo.syncInterval || targetInfo.schedule || 'P0D',
+          syncInterval: tgt.syncInterval || targetInfo.schedule || 'P0D',
           syncIntervalDefault: targetInfo.schedule,
           config: _.sortBy(_.transform(tgt.config, (res, value, key) => {
             const configData = _.get(targetInfo.props, key, false)


### PR DESCRIPTION
This fix issue #2443 (and maybe partially #1158)

When updating a sync interval, the value is updated in database however, the client display always the default time (e.g. 5 min with git storage). The fix simply gets_syncInterval_ value from the model rather than the module data storage.