### PR TITLE
Fix #2995 - syntax error in rebuild-tree.js

### DIFF
--- a/server/jobs/rebuild-tree.js
+++ b/server/jobs/rebuild-tree.js
@@ -57,7 +57,7 @@ module.exports = async (pageId) => {
     await WIKI.models.knex.table('pageTree').truncate()
     if (tree.length > 0) {
       // -> Save in chunks, because of per query max parameters (35k Postgres, 2k MSSQL, 1k for SQLite)
-      if ((WIKI.config.db.type !== 'sqlite'))
+      if ((WIKI.config.db.type !== 'sqlite')) {
         for (const chunk of _.chunk(tree, 100)) {
           await WIKI.models.knex.table('pageTree').insert(chunk)
         }


### PR DESCRIPTION
Fixes #2995 which was caused by a syntax error introduced in `rebuild-tree.js`.
