### PR TITLE
Fix Rocket.Chat auth module

### DIFF
--- a/server/modules/authentication/rocketchat/authentication.js
+++ b/server/modules/authentication/rocketchat/authentication.js
@@ -23,7 +23,7 @@ module.exports = {
           cb(null, {
             id: usr._id,
             displayName: _.isEmpty(usr.name) ? usr.username : usr.name,
-            email: usr.email,
+            email: usr.emails[0].address,
             picture: usr.avatarUrl
           })
         } catch (err) {


### PR DESCRIPTION
As mentioned in #2572, Wiki.js uses the wrong property to access a users' E-Mail address in the Rocket.Chat auth module.

This PR fixes this.

I have tested this change with the current `dev` branch on one of my servers and it's working.

Rocket.Chat's response contains an array containing all the emails a user has added to Rocket.Chat. The currently used property `email` does not exist in the response. Please see https://docs.rocket.chat/api/rest-api/methods/authentication/me.

**Since we have no option to choose  which E-Mail to use for the OAuth mechanism, I just assumed, we take the first one in the array and go for it.**

Please tell me, if you are OK with this, since it can be considered as a dirty hack. 
I can add some validation that checks, if the array is empty that throws an error or something.