### PR TITLE
Error modal when uploading assets with already existing name

### DIFF
--- a/client/components/editor/editor-modal-media.vue
+++ b/client/components/editor/editor-modal-media.vue
@@ -379,6 +379,14 @@ export default {
           icon: 'warning'
         })
       }
+      const conflictingFiles = _.intersectionWith(files, this.assets, (f, a) => f.filename === a.filename)
+      if (conflictingFiles.length > 0) {
+        return this.$store.commit('showNotification', {
+            message: this.$t('editor:assets.conflictingFileNames'),
+            style: 'error',
+            icon: 'error'
+          })
+      }
       for (let file of files) {
         file.setMetadata({
           folderId: this.currentFolderId


### PR DESCRIPTION
This fixes #3159.

The added snippet compares the names of the assets to upload with the names of the already existing assets in the current folder. If there is a conflict an error modal explains the issue and no file is uploaded (even the one with no names conflict).

Note: If another asset with the same name exists but in a different folder no error modal is raised and the files are uploaded.

This PR need the following translation to be added (currently in `server/locales/en.yml`):
```yml
editor:
  assets.conflictingFileNames: 'Conflicting file names, please rename the uploaded assets.'
```

Demo:

![demo.png](https://user-images.githubusercontent.com/38159029/109818280-1e645400-7c33-11eb-8dd8-6936fc6d1836.png)
