### PR TITLE
fix: loginRedirect doesn't work for non local strategies

### DIFF
--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -71,7 +71,19 @@ router.all('/login/:strategy/callback', async (req, res, next) => {
       strategy: req.params.strategy
     }, { req, res })
     res.cookie('jwt', authResult.jwt, { expires: moment().add(1, 'y').toDate() })
-    res.redirect(authResult.redirect)
+
+    const loginRedirect = req.cookies['loginRedirect']
+    if (loginRedirect === '/' && authResult.redirect) {
+      res.clearCookie('loginRedirect')
+      res.redirect(authResult.redirect)
+    } else if (loginRedirect) {
+      res.clearCookie('loginRedirect')
+      res.redirect(loginRedirect)
+    } else if (authResult.redirect) {
+      res.redirect(authResult.redirect)
+    } else {
+      res.redirect('/')
+    }
   } catch (err) {
     next(err)
   }


### PR DESCRIPTION
For the local authentication strategy the loginRedirect cookie is read in login.vue and will redirect the user to the page they requested before needing to login. If you aren't using the local authentication strategy, but instead are using a different strategy, like OpenID Connect etc then logins aren't redirected back to the desired location. Fix this so behavior is the same whether using the local strategy or a different one. Fix based on what is done in login.vue.

