### PR TITLE
Fix HSTS header max-age value.

### DIFF
--- a/server/middlewares/security.js
+++ b/server/middlewares/security.js
@@ -33,7 +33,7 @@ module.exports = function (req, res, next) {
 
   // -> Enforce HSTS
   if (WIKI.config.security.securityHSTS) {
-    res.set('Strict-Transport-Security', `max-age=${WIKI.config.securityHSTSDuration}; includeSubDomains`)
+    res.set('Strict-Transport-Security', `max-age=${WIKI.config.security.securityHSTSDuration}; includeSubDomains`)
   }
 
   // -> Prevent Open Redirect from user provided URL


### PR DESCRIPTION
Wiki.js uses the wrong property to access the saved value for the max-age field of the Strict-Transport-Security HTTP response header. After enabling the "Enforce HSTS" option in the administration area, under the "Security" section, One would expect a new HTTP response header to be set like:
`Strict-Transport-Security: max-age=600; includeSubDomains`
Instead, this header is set:
`Strict-Transport-Security: max-age=undefined; includeSubDomains`
This is invalid according to [RFC 6797](https://tools.ietf.org/html/rfc6797#section-6.1.1) and we cannot expect browsers to correctly apply the intended HSTS policy.

This PR fixes this.

I have tested this change with the current dev branch on one of my servers and it's working.