### PR TITLE
Fix S3 copyObject usage - Missing bucket name

### DIFF
--- a/server/modules/storage/s3/common.js
+++ b/server/modules/storage/s3/common.js
@@ -22,7 +22,7 @@ const getFilePath = (page, pathKey) => {
 module.exports = class S3CompatibleStorage {
   constructor(storageName) {
     this.storageName = storageName
-    this.bucketName
+    this.bucketName = ""
   }
   async activated() {
     // not used

--- a/server/modules/storage/s3/common.js
+++ b/server/modules/storage/s3/common.js
@@ -22,6 +22,7 @@ const getFilePath = (page, pathKey) => {
 module.exports = class S3CompatibleStorage {
   constructor(storageName) {
     this.storageName = storageName
+    this.bucketName;
   }
   async activated() {
     // not used
@@ -32,6 +33,7 @@ module.exports = class S3CompatibleStorage {
   async init() {
     WIKI.logger.info(`(STORAGE/${this.storageName}) Initializing...`)
     const { accessKeyId, secretAccessKey, bucket } = this.config
+    this.bucketName = bucket;
     const s3Config = {
       accessKeyId,
       secretAccessKey,
@@ -89,7 +91,8 @@ module.exports = class S3CompatibleStorage {
         destinationFilePath = `${page.destinationLocaleCode}/${destinationFilePath}`
       }
     }
-    await this.s3.copyObject({ CopySource: sourceFilePath, Key: destinationFilePath }).promise()
+
+    await this.s3.copyObject({ CopySource: `${this.bucketName}/${sourceFilePath}`, Key: destinationFilePath }).promise()
     await this.s3.deleteObject({ Key: sourceFilePath }).promise()
   }
   /**
@@ -117,7 +120,7 @@ module.exports = class S3CompatibleStorage {
    */
   async assetRenamed (asset) {
     WIKI.logger.info(`(STORAGE/${this.storageName}) Renaming file from ${asset.path} to ${asset.destinationPath}...`)
-    await this.s3.copyObject({ CopySource: asset.path, Key: asset.destinationPath }).promise()
+    await this.s3.copyObject({ CopySource: `${this.bucketName}/${asset.path}`, Key: asset.destinationPath }).promise()
     await this.s3.deleteObject({ Key: asset.path }).promise()
   }
   async getLocalLocation () {

--- a/server/modules/storage/s3/common.js
+++ b/server/modules/storage/s3/common.js
@@ -91,7 +91,6 @@ module.exports = class S3CompatibleStorage {
         destinationFilePath = `${page.destinationLocaleCode}/${destinationFilePath}`
       }
     }
-
     await this.s3.copyObject({ CopySource: `${this.bucketName}/${sourceFilePath}`, Key: destinationFilePath }).promise()
     await this.s3.deleteObject({ Key: sourceFilePath }).promise()
   }

--- a/server/modules/storage/s3/common.js
+++ b/server/modules/storage/s3/common.js
@@ -22,7 +22,7 @@ const getFilePath = (page, pathKey) => {
 module.exports = class S3CompatibleStorage {
   constructor(storageName) {
     this.storageName = storageName
-    this.bucketName;
+    this.bucketName
   }
   async activated() {
     // not used
@@ -33,7 +33,6 @@ module.exports = class S3CompatibleStorage {
   async init() {
     WIKI.logger.info(`(STORAGE/${this.storageName}) Initializing...`)
     const { accessKeyId, secretAccessKey, bucket } = this.config
-    this.bucketName = bucket;
     const s3Config = {
       accessKeyId,
       secretAccessKey,
@@ -58,6 +57,7 @@ module.exports = class S3CompatibleStorage {
     }
 
     this.s3 = new S3(s3Config)
+    this.bucketName = bucket
 
     // determine if a bucket exists and you have permission to access it
     await this.s3.headBucket().promise()


### PR DESCRIPTION
## Problem
Currently, upon moving/renaming files in wiki with AWS S3 storage setup, we get `Access Denied`/`Invalid object key` errors from AWS.

## Solution
- As specified in [S3 docs](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#copyObject-property), the `copyObject` method requires the `CopySource` field to supply the bucket name in the path. 
- As such I have prepend the `bucketName` to `CopySource` fields. 

Let me know if this change is OK. I can make any change necessary to follow the repo's guidance. 

