### PR TITLE
Optionally always redirect user to login page if they are not authenticated fixes #3744

### DIFF
--- a/client/components/admin/admin-security.vue
+++ b/client/components/admin/admin-security.vue
@@ -171,6 +171,15 @@
                     )
                   v-switch(
                     inset
+                    :label='$t(`admin:security.bypassUnauthorized`)'
+                    color='primary'
+                    v-model='config.authBypassUnauthorized'
+                    prepend-icon='mdi-fast-forward'
+                    persistent-hint
+                    :hint='$t(`admin:security.bypassUnauthorizedHint`)'
+                    )
+                  v-switch(
+                    inset
                     :label='$t(`admin:security.hideLocalLogin`)'
                     color='primary'
                     v-model='config.authHideLocal'
@@ -252,6 +261,7 @@ export default {
         securityCSP: false,
         securityCSPDirectives: '',
         authAutoLogin: false,
+        authBypassUnauthorized: false,
         authHideLocal: false,
         authLoginBgUrl: '',
         authJwtAudience: 'urn:wiki.js',
@@ -278,6 +288,7 @@ export default {
           mutation: gql`
             mutation (
               $authAutoLogin: Boolean
+              $authBypassUnauthorized: Boolean
               $authEnforce2FA: Boolean
               $authHideLocal: Boolean
               $authLoginBgUrl: String
@@ -299,6 +310,7 @@ export default {
               site {
                 updateConfig(
                   authAutoLogin: $authAutoLogin,
+                  authBypassUnauthorized: $authBypassUnauthorized,
                   authEnforce2FA: $authEnforce2FA,
                   authHideLocal: $authHideLocal,
                   authLoginBgUrl: $authLoginBgUrl,
@@ -329,6 +341,7 @@ export default {
           `,
           variables: {
             authAutoLogin: _.get(this.config, 'authAutoLogin', false),
+            authBypassUnauthorized: _.get(this.config, 'authBypassUnauthorized', false),
             authEnforce2FA: _.get(this.config, 'authEnforce2FA', false),
             authHideLocal: _.get(this.config, 'authHideLocal', false),
             authLoginBgUrl: _.get(this.config, 'authLoginBgUrl', ''),
@@ -380,6 +393,7 @@ export default {
           site {
             config {
               authAutoLogin
+              authBypassUnauthorized
               authEnforce2FA
               authHideLocal
               authLoginBgUrl

--- a/server/app/data.yml
+++ b/server/app/data.yml
@@ -55,6 +55,7 @@ defaults:
       darkMode: false
     auth:
       autoLogin: false
+      bypassUnauthorized: false
       enforce2FA: false
       hideLocal: false
       loginBgUrl: ''

--- a/server/controllers/common.js
+++ b/server/controllers/common.js
@@ -444,7 +444,11 @@ router.get('/*', async (req, res, next) => {
             maxAge: 15 * 60 * 1000
           })
         }
-        if (pageArgs.path === 'home' && req.user.id === 2) {
+
+        // If the user is the guest user (id 2) and either trying to access the home page for the wiki
+        // or the wiki is configured to not show unauthorized for the guest user,
+        // redirect to the login page for the wiki.
+        if ((pageArgs.path === 'home' || WIKI.config.auth.bypassUnauthorized) && req.user.id === 2) {
           return res.redirect('/login')
         }
         _.set(res.locals, 'pageMeta.title', 'Unauthorized')

--- a/server/graph/resolvers/site.js
+++ b/server/graph/resolvers/site.js
@@ -22,6 +22,7 @@ module.exports = {
         ...WIKI.config.features,
         ...WIKI.config.security,
         authAutoLogin: WIKI.config.auth.autoLogin,
+        authBypassUnauthorized: WIKI.config.auth.bypassUnauthorized,
         authEnforce2FA: WIKI.config.auth.enforce2FA,
         authHideLocal: WIKI.config.auth.hideLocal,
         authLoginBgUrl: WIKI.config.auth.loginBgUrl,
@@ -69,6 +70,7 @@ module.exports = {
 
         WIKI.config.auth = {
           autoLogin: _.get(args, 'authAutoLogin', WIKI.config.auth.autoLogin),
+          bypassUnauthorized: _.get(args, 'authBypassUnauthorized', WIKI.config.auth.bypassUnauthorized),
           enforce2FA: _.get(args, 'authEnforce2FA', WIKI.config.auth.enforce2FA),
           hideLocal: _.get(args, 'authHideLocal', WIKI.config.auth.hideLocal),
           loginBgUrl: _.get(args, 'authLoginBgUrl', WIKI.config.auth.loginBgUrl),

--- a/server/graph/schemas/site.graphql
+++ b/server/graph/schemas/site.graphql
@@ -34,6 +34,7 @@ type SiteMutation {
     contentLicense: String
     logoUrl: String
     authAutoLogin: Boolean
+    authBypassUnauthorized: Boolean
     authEnforce2FA: Boolean
     authHideLocal: Boolean
     authLoginBgUrl: String
@@ -73,6 +74,7 @@ type SiteConfig {
   contentLicense: String!
   logoUrl: String!
   authAutoLogin: Boolean
+  authBypassUnauthorized: Boolean
   authEnforce2FA: Boolean
   authHideLocal: Boolean
   authLoginBgUrl: String


### PR DESCRIPTION
If a wiki is configured to be private, eg guest does not have any permissions to view any of the pages on the wiki, it is an annoyance to always be told that you aren't authorized to view a page when you aren't logged in. A more natural flow in this sort of scenario would be to be automatically directed to the login page so that the user can authenticate (and then hopefully gain access to the page).

This change adds a configuration option to the security page to enable "Bypass Unauthorized Screen" functionality. This option defaults to false, so there is no change in behavior for existing/new installations, it is an opt-in configuration change.

Two new translatable strings are required:
```
"admin:security.bypassUnauthorized": "Bypass Unauthorized Screen"
"admin:security.bypassUnauthorizedHint": "Should the user be redirected automatically to the login screen if they are not authenticated and attempt to access a page not accessible to Guest"
```

![image](https://user-images.githubusercontent.com/73899671/113015313-551b8480-9175-11eb-9123-1c768bff3d2b.png)

I have tested various scenarios here when trying to access a page that Guest is not authorised to:
db doesn't have config option set at all - Unauthorised page shown
db has config option set to false - Unauthorized page shown
db has config option set to true - Redirected to login page automatically

new strings have been tested in a dev en.yml file.