### PR TITLE
feat: add support for embedding audio/video in the HTML5 way

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "markdown-it-expand-tabs": "1.0.13",
     "markdown-it-external-links": "0.0.6",
     "markdown-it-footnote": "3.0.2",
+    "markdown-it-html5-embed": "1.0.0",
     "markdown-it-imsize": "2.0.1",
     "markdown-it-mark": "3.0.0",
     "markdown-it-mathjax": "2.0.0",

--- a/server/modules/rendering/markdown-html-5-embed/definition.yml
+++ b/server/modules/rendering/markdown-html-5-embed/definition.yml
@@ -1,0 +1,20 @@
+key: markdownHtml5Embed
+title: HTML5 Embed
+description: HTML5 Audio/Video Embed for Markdown
+author: silviu@lorent.ro
+icon: mdi-language-markdown
+enabledDefault: true
+dependsOn: markdownCore
+props:
+  useImageSyntax:
+    type: Boolean
+    default: true
+    title: Use Image Syntax
+    hint: Enables video/audio embed with ![]() syntax
+    order: 1
+  useLinkSyntax:
+    type: Boolean
+    default: false
+    title: Use Link Syntax
+    hint: Enables video/audio embed with []() syntax
+    order: 2

--- a/server/modules/rendering/markdown-html-5-embed/renderer.js
+++ b/server/modules/rendering/markdown-html-5-embed/renderer.js
@@ -1,0 +1,16 @@
+const mdHtml5 = require('markdown-it-html5-embed');
+
+// ------------------------------------
+// Markdown - HTML5 Audio/Video
+// ------------------------------------
+
+module.exports = {
+  init (md, conf) {
+    md.use(mdHtml5, {
+      html5embed: {
+        useImageSyntax: conf.useImageSyntax, // Enables video/audio embed with ![]() syntax (default)
+        useLinkSyntax: conf.useLinkSyntax // Enables video/audio embed with []() syntax
+      }
+    })
+  }
+};


### PR DESCRIPTION
## Problem

You can upload and link to audio/video files inside Wiki.js pages; however, there is no way to play them from inside the page.

## Solution

I have created a module which leverages the `markdown-it-html5-embed` library to provide support for embedding uploaded audio/video inside Wiki.js pages.

### Disclaimer

I am new to the community and to open-source contributions altogether, so please let me know if there is anything I should be doing differently. Thank you!