### PR TITLE
fix: graceful shutdown

### DIFF
--- a/server/core/asar.js
+++ b/server/core/asar.js
@@ -40,11 +40,11 @@ module.exports = {
     }
   },
   async unload () {
-    if (this.fdCache) {
+    const fds = Object.values(this.fdCache)
+    if (fds.length > 0) {
       WIKI.logger.info('Closing ASAR file descriptors...')
-      for (const fdItem in this.fdCache) {
-        fs.closeSync(this.fdCache[fdItem].fd)
-      }
+      const closeAsync = require('util').promisify(fs.close)
+      await Promise.all(fds.map(x => closeAsync(x.fd)))
       this.fdCache = {}
     }
   },

--- a/server/core/kernel.js
+++ b/server/core/kernel.js
@@ -107,19 +107,21 @@ module.exports = {
    * Graceful shutdown
    */
   async shutdown () {
-    if (WIKI.models) {
-      await WIKI.models.unsubscribeToNotifications()
-      await WIKI.models.knex.client.pool.destroy()
-      await WIKI.models.knex.destroy()
+    if (WIKI.servers) {
+      await WIKI.servers.stopServers()
     }
     if (WIKI.scheduler) {
-      WIKI.scheduler.stop()
+      await WIKI.scheduler.stop()
+    }
+    if (WIKI.models) {
+      await WIKI.models.unsubscribeToNotifications()
+      if (WIKI.models.knex) {
+        await WIKI.models.knex.destroy()
+      }
     }
     if (WIKI.asar) {
       await WIKI.asar.unload()
     }
-    if (WIKI.servers) {
-      await WIKI.servers.stopServers()
-    }
+    process.exit(0)
   }
 }

--- a/server/index.js
+++ b/server/index.js
@@ -33,3 +33,16 @@ WIKI.logger = require('./core/logger').init('MASTER')
 // ----------------------------------------
 
 WIKI.kernel.init()
+
+// ----------------------------------------
+// Register exit handler
+// ----------------------------------------
+
+process.on('SIGINT', () => {
+  WIKI.kernel.shutdown()
+})
+process.on('message', (msg) => {
+  if (msg === 'shutdown') {
+    WIKI.kernel.shutdown()
+  }
+})


### PR DESCRIPTION
There is a graceful shutdown procedure written in the kernel, but not registered with the process exit handler.

This change adds:
- a SIGINT handler,
- a PM2 specific message handler on windows platform,
- and properly shutdown the scheduler and wait for running jobs to complete before exiting.