### PR TITLE
fix: pass through job error from worker process

### DIFF
--- a/server/core/worker.js
+++ b/server/core/worker.js
@@ -14,6 +14,11 @@ WIKI.logger = require('./logger').init('JOB')
 const args = require('yargs').argv
 
 ;(async () => {
-  await require(`../jobs/${args.job}`)(args.data)
-  process.exit(0)
+  try {
+    await require(`../jobs/${args.job}`)(args.data)
+    process.exit(0)
+  } catch (e) {
+    await new Promise(resolve => process.stderr.write(e.message, resolve))
+    process.exit(1)
+  }
 })()

--- a/server/jobs/rebuild-tree.js
+++ b/server/jobs/rebuild-tree.js
@@ -74,5 +74,7 @@ module.exports = async (pageId) => {
   } catch (err) {
     WIKI.logger.error(`Rebuilding page tree: [ FAILED ]`)
     WIKI.logger.error(err.message)
+    // exit process with error code
+    throw err
   }
 }

--- a/server/jobs/render-page.js
+++ b/server/jobs/render-page.js
@@ -90,5 +90,7 @@ module.exports = async (pageId) => {
   } catch (err) {
     WIKI.logger.error(`Rendering page ID ${pageId}: [ FAILED ]`)
     WIKI.logger.error(err.message)
+    // exit process with error code
+    throw err
   }
 }


### PR DESCRIPTION
When scheduled jobs are run in a separated worker, the errors are only logged, but never propagated back to the master process. This behavior can cause misleading feedback to the user, especially when those jobs are triggered on-demand by a user action (namely `rebuild-tree`, `render-page`), which the user thinks the request completed successfully if no error is reported. (example case: https://github.com/Requarks/wiki/discussions/3709#discussioncomment-596783)

This change provides some means to communicate back the error of the worker process if it failed.