### PR TITLE
Increase bodyParser limit

### DIFF
--- a/server/master.js
+++ b/server/master.js
@@ -91,7 +91,7 @@ module.exports = async () => {
   // GraphQL Server
   // ----------------------------------------
 
-  app.use(bodyParser.json({ limit: '1mb' }))
+  app.use(bodyParser.json({ limit: '20mb' }))
   await WIKI.servers.startGraphQL()
 
   // ----------------------------------------


### PR DESCRIPTION
Because it is impossible to save a wiki page with a big draw.io diagram it is necessary to increase the bodyParser limit.

See: https://github.com/Requarks/wiki/issues/2797

