### PR TITLE
Improve Helm README (existing postgresql Secret)

### DIFF
--- a/dev/helm/README.md
+++ b/dev/helm/README.md
@@ -107,6 +107,8 @@ The following table lists the configurable parameters of the Wiki.js chart and t
 | `postgresql.postgresqlUser`            | Postgres username                           | `postgres`                                                   |
 | `postgresql.postgresqlHost`            | External postgres host                      | `nil`                                                      |
 | `postgresql.postgresqlPassword`        | External postgres password                  | `nil`                                                      |
+| `postgresql.existingSecret`            | Provide an existing `Secret` for postgres   | `nil`                                                      |
+| `postgresql.existingSecretKey`          | The postgres password key in the existing `Secret`   | `postgresql-password`                              |
 | `postgresql.postgresqlPort`            | External postgres port                      | `5432`                                                     |
 | `postgresql.ssl`                       | Enable external postgres SSL connection     | `false`                                                   |
 | `postgresql.ca`                        | Certificate of Authority path for postgres  | `nil`                                                     |
@@ -137,11 +139,11 @@ By default, PostgreSQL is installed as part of the chart.
 
 ### Using an external PostgreSQL server
 
-To use an external PostgreSQL server, set `postgresql.enabled` to `false` and then set `postgresql.postgresqlHost` and `postgresql.postgresqlPassword`. The other options (`postgresql.postgresqlDatabase`, `postgresql.postgresqlUser` and `postgresql.postgresqlPort`) may also want changing from their default values.
+To use an external PostgreSQL server, set `postgresql.enabled` to `false` and then set `postgresql.postgresqlHost` and `postgresql.postgresqlPassword`. To use an existing `Secret`, set `postgresql.existingSecret`. The other options (`postgresql.postgresqlDatabase`, `postgresql.postgresqlUser`, `postgresql.postgresqlPort` and `postgresql.existingSecretKey`) may also want changing from their default values.
 
 To use an SSL connection you can set `postgresql.ssl` to `true` and if needed the path to a Certificate of Authority can be set using `postgresql.ca` to `/path/to/ca`. Default `postgresql.ssl` value is `false`.
 
-You also need to add the follow Helm template to your deployment:
+If `postgresql.existingSecret` is not specified, you also need to add the following Helm template to your deployment in order to create the postgresql `Secret`:
 
 ```yaml
 kind: Secret


### PR DESCRIPTION
Small doc improvements:
- Add the 2 missing parameters `postgresql.existingSecret` and `postgresql.existingSecretKey` in the list.
- Update the **"Using an external PostgreSQL server"** part by specifying how to use an existing postgresql Secret

