### PR TITLE
Add support of `hd` google auth parameter - to work with G Suite domains

### DIFF
--- a/server/modules/authentication/google/authentication.js
+++ b/server/modules/authentication/google/authentication.js
@@ -9,27 +9,38 @@ const _ = require('lodash')
 
 module.exports = {
   init (passport, conf) {
-    passport.use('google',
-      new GoogleStrategy({
-        clientID: conf.clientId,
-        clientSecret: conf.clientSecret,
-        callbackURL: conf.callbackURL,
-        passReqToCallback: true
-      }, async (req, accessToken, refreshToken, profile, cb) => {
-        try {
-          const user = await WIKI.models.users.processProfile({
-            providerKey: req.params.strategy,
-            profile: {
-              ...profile,
-              picture: _.get(profile, 'photos[0].value', '')
-            }
-          })
-          cb(null, user)
-        } catch (err) {
-          cb(err, null)
+    var strategy = new GoogleStrategy({
+      clientID: conf.clientId,
+      clientSecret: conf.clientSecret,
+      callbackURL: conf.callbackURL,
+      passReqToCallback: true
+    }, async (req, accessToken, refreshToken, profile, cb) => {
+      try {
+        if (conf.hostedDomain && conf.hostedDomain != profile._json.hd) {
+          throw new Error('Google authentication should have been performed with domain ' + conf.hostedDomain)
         }
-      })
-    )
+        const user = await WIKI.models.users.processProfile({
+          providerKey: req.params.strategy,
+          profile: {
+            ...profile,
+            picture: _.get(profile, 'photos[0].value', '')
+          }
+        })
+        cb(null, user)
+      } catch (err) {
+        cb(err, null)
+      }
+    });
+
+    if (conf.hostedDomain) {
+      strategy.authorizationParams = function(options) {
+        return {
+          'hd' : conf.hostedDomain
+        };
+      };
+    }
+
+    passport.use('google', strategy)
   },
   logout (conf) {
     return '/'

--- a/server/modules/authentication/google/authentication.js
+++ b/server/modules/authentication/google/authentication.js
@@ -9,7 +9,7 @@ const _ = require('lodash')
 
 module.exports = {
   init (passport, conf) {
-    var strategy = new GoogleStrategy({
+    const strategy = new GoogleStrategy({
       clientID: conf.clientId,
       clientSecret: conf.clientSecret,
       callbackURL: conf.callbackURL,
@@ -30,14 +30,14 @@ module.exports = {
       } catch (err) {
         cb(err, null)
       }
-    });
+    })
 
     if (conf.hostedDomain) {
       strategy.authorizationParams = function(options) {
         return {
-          'hd' : conf.hostedDomain
-        };
-      };
+          hd: conf.hostedDomain
+        }
+      }
     }
 
     passport.use('google', strategy)

--- a/server/modules/authentication/google/definition.yml
+++ b/server/modules/authentication/google/definition.yml
@@ -22,3 +22,8 @@ props:
     title: Client Secret
     hint: Application Client Secret
     order: 2
+  hostedDomain:
+    type: String
+    title: Hosted domain
+    hint: hd Authentication URI parameter - streamlines the login process for G Suite hosted domain
+    order: 3

--- a/server/modules/authentication/google/definition.yml
+++ b/server/modules/authentication/google/definition.yml
@@ -24,6 +24,6 @@ props:
     order: 2
   hostedDomain:
     type: String
-    title: Hosted domain
-    hint: hd Authentication URI parameter - streamlines the login process for G Suite hosted domain
+    title: Hosted Domain
+    hint: (optional) Only for G Suite hosted domain. Leave empty otherwise.
     order: 3


### PR DESCRIPTION
Similar to #608, I'm adding support of hd / hostedDomain functionality to the google auth module. The setting is needed to enable the account selection UI optimization when limiting the authentication to the company domain.

For additional info: https://developers.google.com/identity/protocols/oauth2/openid-connect#authenticationuriparameters

Note: I'm not a JS developer so please check the code after me.