### PR TITLE
feat(helm): adding liveness and readiness probes customizations 

### DIFF
--- a/dev/helm/Chart.yaml
+++ b/dev/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wiki
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.0
+version: 2.2.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 AppVersion: latest

--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -56,13 +56,9 @@ spec:
               containerPort: 3000
               protocol: TCP
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /healthz
-              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -21,6 +21,16 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
## What does this PR do ?

It adds the ability to completely customize the liveness probe and readiness probe of the wikijs deployment in the helm chart.

The actual configuration DOES NOT change the probes defined before : users who do not care about this change won't notice anything.

## Why this PR ?

I opened this PR because when I deployed wikijs via helm, after install the pod was crashlooping because it was too slow to start, and the probe keep restarting it, so I looked for more customizations of the probe and I got none, so I decided to make it myself and share it.

## Where should the reviewer start ?

The two files changed are the deployment of wikijs : dev/helm/templates/deployment.yaml and the default values file in dev/helm/values.yaml

## Tests

Using `helm template .` renders the same deployment as before the change, so I think it does not break anything.

Step to reproduce : 

1. clone the base repo, branch dev : `helm template test-release . > ~/.test-base`
2. clone my fork (https://github.com/larueli/wiki.git), branch dev : `helm template test-release . > ~/.test-fork`
3. Compare : `diff ~/.test-base ~/.test-fork`

## Anything else ?

Should I add an option to remove probes ?