### PR TITLE
Add scrollbar for big diagrams

### DIFF
--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -583,6 +583,7 @@
 
   .diagram {
     margin-top: 1rem;
+    overflow: auto;
     svg:first-child {
       direction: ltr;
     }


### PR DESCRIPTION
### What does this PR do?
It adds the ability to automatically enable scrollbars when a DrawIO diagram width is higher than the browser/screen width. 

### Why this PR?
We have documentation with complex diagrams, that are sometimes very big.
Unfortunately, the access to these diagram is today unusable, beacause a part of them is not displayed. The reason is that their size is not adapted to the browser/screen size OR a scrollbar is not enabled. 
I have decided to suggest this small fix (a new field in the CSS class .diagram) as it is a simple workaround enabling scrollbars.

### Tests
You can test the change locally in your web browser by editting dynamically your CSS class or inject directly the CSS code in the Theme section of the admin page:

```css
.diagram {
  overflow: auto
}
``` 

