### PR TITLE
Auto installer (latest branch)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true
+}
+

--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -26,8 +26,12 @@ spec:
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ default "latest" .Values.image.tag }}"
-          imagePullPolicy: {{ default "IfNotPresent" .Values.image.imagePullPolicy }}
+          imagePullPolicy: {{ default "IfNotPresent" .Values.image.pullPolicy }}
           env:
+            {{- range $key, $value := $.Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
             - name: DB_TYPE
               value: postgres
             - name: DB_HOST

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "filesize": "6.1.0",
     "fs-extra": "9.0.1",
     "getos": "3.2.1",
+    "got": "11.8.2",
     "graphql": "15.3.0",
     "graphql-list-fields": "2.0.2",
     "graphql-rate-limit-directive": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "graphql-rate-limit-directive": "1.2.1",
     "graphql-subscriptions": "1.1.0",
     "graphql-tools": "7.0.0",
+    "graphql-upload": "^8.0.0",
     "he": "1.2.0",
     "highlight.js": "10.3.1",
     "i18next": "19.8.3",

--- a/server/setup.js
+++ b/server/setup.js
@@ -14,6 +14,14 @@ const semver = require('semver')
 
 /* global WIKI */
 
+async function autoInstall() {
+  const got = require('got')
+
+  await got.post(`http://localhost:${WIKI.config.port}/finalize`, {
+    json: JSON.parse(process.env.AUTO_CONFIG)
+  })
+}
+
 module.exports = () => {
   WIKI.config.site = {
     path: '',
@@ -265,6 +273,16 @@ module.exports = () => {
         strategyKey: 'local',
         displayName: 'Local'
       })
+      
+      // only on auto install right now, should add some
+      // param validation before opening as general api
+      if (req.body.authenticationProvider && process.env.AUTO_INSTALL) {
+        // adds an authentication provider from the start
+        await WIKI.models.authentication.query().insert({
+          ...req.body.authenticationProvider,
+          order: 1
+        })
+      }
 
       // Load editors + enable default
       await WIKI.models.editors.refreshEditorsFromDisk()
@@ -446,5 +464,7 @@ module.exports = () => {
     WIKI.logger.info(`Browse to http://YOUR-SERVER-IP:${WIKI.config.port}/ to complete setup!`)
     WIKI.logger.info('')
     WIKI.logger.info('🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺🔺')
+
+    if (process.env.AUTO_INSTALL) autoInstall()
   })
 }


### PR DESCRIPTION
Same as #4227 but for the latest branch

# Description 

This is an auto installer for installations in a fully automated kubernetes install. A customer needed this b/c he wants to roll it out to all the subsidiaries with the least amount of frictions possible. Since this will be useful for everyone I decided not to do an out of tree implementation.

# Notes

- `got` was added as a dependency. This project is still using request, however request is dead and deprecated for long time already. `got` is the `node.js` sides new project that fits into the spot of request best. Especially due to fine grained control over network parameters (such as socket timeouts, ssl timeouts, ...) 
- the `setup.js` file was rewritten by my auto fixer, if necessary will adjust that somewhat later, I would suggest you to add a .eslintrc or .prettierrc or both to the project to make sure that your repo standards are well defined and no one has to learn your code style standards and by that decrease interaction.
- the graphql-upload dependency was implicit, but the lock file does not get used during the build. so it was broken and added specifically