### PR TITLE
When clicking anchor links, get the a tag by using MouseEvent.currentTarget...

### DIFF
--- a/client/themes/default/components/page.vue
+++ b/client/themes/default/components/page.vue
@@ -579,7 +579,7 @@ export default {
         el.onclick = ev => {
           ev.preventDefault()
           ev.stopPropagation()
-          this.$vuetify.goTo(decodeURIComponent(ev.target.hash), this.scrollOpts)
+          this.$vuetify.goTo(decodeURIComponent(ev.currentTarget.hash), this.scrollOpts)
         }
       })
     })


### PR DESCRIPTION
… instead of just .target: that way if there are any DOM nodes as children of the a tag, it won't grab them, which causes an exception to happen, as they don't have a hash property (only the original a tag has the hash). Fixes issue: #4235

