### PR TITLE
Fix post size limitation

### DIFF
--- a/server/master.js
+++ b/server/master.js
@@ -36,6 +36,8 @@ module.exports = async () => {
   const app = express()
   WIKI.app = app
   app.use(compression())
+  app.use(express.urlencoded({limit: '1024mb'}))
+  app.use(express.json({limit: '1024mb'}))
 
   // ----------------------------------------
   // Security


### PR DESCRIPTION
With express module default setting, articles with large size of content (in my case, such as has many diagrams with image data) will fail to upload with a 413 error.
Try to fix this situation by specifying the max body size.

Cheers