### PR TITLE
chore: add script to package wiki for a local install

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+dist
+node_modules
+.webpack-cache
+assets
+data

--- a/build-local-release.sh
+++ b/build-local-release.sh
@@ -1,0 +1,34 @@
+#! /bin/bash
+
+set -e
+
+### Performs a local build of the project                 ###
+### Useful for when you require a local/forked full build ###
+
+LOCAL_BUILD_VER=${1:-"local"}
+STAGING_DIR=${2:-./dist}
+
+if ! command -v jq &> /dev/null; then echo "jq required!"; exit; fi
+cleanup_containers() {
+  echo "cleaning 'wiki-builder' containers"
+  docker stop wiki-builder && docker rm wiki-builder
+}
+
+echo "mutating package.json"
+cat <<< "$(jq '.dev |= false' package.json)" > package.json
+cat <<< "$(jq '.version |= "local"' package.json)" > package.json
+
+echo "building image requarks/wiki:${LOCAL_BUILD_VER}"
+docker build --file dev/build/Dockerfile . --tag requarks/wiki:${LOCAL_BUILD_VER}
+rm -rf ${STAGING_DIR} && mkdir -p ${STAGING_DIR}
+cleanup_containers || true
+
+echo "compressing files to ${STAGING_DIR}"
+docker run --detach --name wiki-builder --entrypoint "/bin/sleep" requarks/wiki:${LOCAL_BUILD_VER} 120
+docker exec -it wiki-builder rm /wiki/config.yml
+docker cp ./config.sample.yml wiki-builder:/wiki/config.sample.yml
+docker exec -u root -w / -it wiki-builder bash -c "tar -czf wiki-js.tar.gz wiki/"
+docker cp wiki-builder:wiki-js.tar.gz ${STAGING_DIR}
+cleanup_containers
+
+echo "Release files in ${STAGING_DIR}: $(ls ${STAGING_DIR})"

--- a/dev/build/Dockerfile
+++ b/dev/build/Dockerfile
@@ -23,7 +23,7 @@ RUN yarn --production --frozen-lockfile --non-interactive
 # ===============
 # --- Release ---
 # ===============
-FROM node:14-alpine
+FROM node:14-alpine AS release
 LABEL maintainer="requarks.io"
 
 RUN apk add bash curl git openssh gnupg sqlite --no-cache && \


### PR DESCRIPTION
This is an attempt to make it easier for folks to be able to run a close-to-production installation off of the main dev branch.

This commit also adds a .dockerignore file to speed up dockerfile builds

