### PR TITLE
Redirect to locale namespace by Accept-Language Header

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@root/csr": "0.8.1",
     "@root/keypairs": "0.10.1",
     "@root/pem": "1.0.4",
+    "accept-language-parser": "1.5.0",
     "acme": "3.0.3",
     "akismet-api": "5.1.0",
     "algoliasearch": "4.5.1",

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -939,6 +939,49 @@ module.exports = class Page extends Model {
 
   /**
    * Fetch an Existing Page from Cache if possible, from DB otherwise and save render to Cache
+   * Fetch list of available locales pf [age]
+   *
+   * @param {Object} opts Page Properties
+   * @param {string} opts.path Page Properties
+   * @returns {Promise} Promise of the list of locales of the Pages with specified path
+   */
+  static async getLocalesOfPage(opts) {
+    try {
+      const rows = await WIKI.models.pages.query()
+        .column(['pages.localeCode'])
+        .withGraphJoined('tags')
+        .modifyGraph('tags', builder => {
+          builder.select('tag', 'title')
+        })
+        .where({
+          'pages.path': opts.path
+        })
+        // .andWhere(builder => {
+        //   if (queryModeID) return
+        //   builder.where({
+        //     'pages.isPublished': true
+        //   }).orWhere({
+        //     'pages.isPublished': false,
+        //     'pages.authorId': opts.userId
+        //   })
+        // })
+        // .andWhere(builder => {
+        //   if (queryModeID) return
+        //   if (opts.isPrivate) {
+        //     builder.where({ 'pages.isPrivate': true, 'pages.privateNS': opts.privateNS })
+        //   } else {
+        //     builder.where({ 'pages.isPrivate': false })
+        //   }
+        // })
+      return rows.map(row => row.localeCode).sort((a, b) => b.length - a.length)
+    } catch (err) {
+      WIKI.logger.warn(err)
+      throw err
+    }
+  }
+
+  /**
+   * Fetch an Existing Page from Cache if possible, from DB otherwise and save render to Cache
    *
    * @param {Object} opts Page Properties
    * @returns {Promise} Promise of the Page Model Instance

--- a/yarn.lock
+++ b/yarn.lock
@@ -4312,6 +4312,11 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+accept-language-parser@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/accept-language-parser/-/accept-language-parser-1.5.0.tgz#8877c54040a8dcb59e0a07d9c1fde42298334791"
+  integrity sha1-iHfFQECo3LWeCgfZwf3kIpgzR5E=
+
 accepts@^1.3.5, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"


### PR DESCRIPTION
Fixes/Implements: [Redirect to user's browser preferred language](https://feedback.js.wiki/wiki/p/redirect-to-users-browser-preferred-language)

I'm planning to use wiki.js. I want to use this feature so I implement this feature.

**TESTING**
I've tested with the following commands (on zsh prompt). The development wiki.js instance has `/home` on english and japanese.
```
$ curl -H "Accept-Language: ja,en-US;q=0.9,en;q=0.8" 'http://localhost:3000/home'
Found. Redirecting to /ja/home%
$ curl -H "Accept-Language: en-US;q=0.9,en;q=0.8" 'http://localhost:3000/home'
Found. Redirecting to /en/home%
$ curl -H "Accept-Language: en-US" 'http://localhost:3000/home'
Found. Redirecting to /en/home%
$ curl -H "Accept-Language: en-US,ja;q=0.9" 'http://localhost:3000/home'
Found. Redirecting to /en/home%
$ curl -H "Accept-Language: fr" 'http://localhost:3000/home'
Found. Redirecting to /ja/home%
```