### PR TITLE
Multiple language support of login page

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@root/csr": "0.8.1",
     "@root/keypairs": "0.10.1",
     "@root/pem": "1.0.4",
+    "accept-language-parser": "1.5.0",
     "acme": "3.0.3",
     "akismet-api": "5.1.0",
     "algoliasearch": "4.5.1",

--- a/server/views/legacy/login.pug
+++ b/server/views/legacy/login.pug
@@ -7,7 +7,7 @@ block body
       .login-dialog
         if err
           .login-error= err.message
-        form(method='post', action='/login')
+        form(method='post', action=localePart + '/login')
           h1= config.title
           select(name='strategy')
             each str in formStrategies

--- a/yarn.lock
+++ b/yarn.lock
@@ -4312,6 +4312,11 @@ abbrev@1:
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
 
+accept-language-parser@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/accept-language-parser/-/accept-language-parser-1.5.0.tgz#8877c54040a8dcb59e0a07d9c1fde42298334791"
+  integrity sha1-iHfFQECo3LWeCgfZwf3kIpgzR5E=
+
 accepts@^1.3.5, accepts@~1.3.5, accepts@~1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.7.tgz#531bc726517a3b2b41f850021c6cc15eaab507cd"


### PR DESCRIPTION
See Also: #4480. `findBestLocale` function in this PR is very similar to `findBestLocaleFor` in #4480. If both is going to be merged, They may be merged.

In this implementation,

1. For `/login`
    1. If locale namespaces are enabled
        1. If client sends `accept-language` which has installed locale
            1. Redirected to `/<locale by accept-language>/login`
        1. Otherwice
            1. Redirected to `/<default locale>/login`
      1. Otherwice
          1. Login form will with default locale be rendered as before
1. For `/<locale>/login`
    1. Login form with specified local will be rendered.