### PR TITLE
TOC Links and Custom Header ID Fix

### DIFF
--- a/server/modules/rendering/html-core/renderer.js
+++ b/server/modules/rendering/html-core/renderer.js
@@ -201,10 +201,11 @@ module.exports = {
 
     let headers = []
     $('h1,h2,h3,h4,h5,h6').each((i, elm) => {
-      if ($(elm).attr('id')) {
-        return
-      }
       let headerSlug = uslug($(elm).text())
+      // -> If custom ID is defined, try to use that instead
+      if ($(elm).attr('id')) {
+        headerSlug = $(elm).attr('id')
+      }
 
       // -> Cannot start with a number (CSS selector limitation)
       if (headerSlug.match(/^\d/)) {


### PR DESCRIPTION
This simple PR fixes the issue where TOC Links fail to work for headers that have been given a custom ID, or when defined in the HTML body as discussed in #3502 

Such as in the scenario below, where Wiki.js will fail to properly generate the page TOC for Header 1
```md
[Link](#custom)
# Header 1 {#custom}
```