### PR TITLE
Remove excess Div wrappers

### DIFF
--- a/server/modules/rendering/html-core/renderer.js
+++ b/server/modules/rendering/html-core/renderer.js
@@ -233,16 +233,6 @@ module.exports = {
     })
 
     // --------------------------------
-    // Wrap root text nodes
-    // --------------------------------
-
-    $('body').contents().toArray().forEach(item => {
-      if (item && item.type === 'text' && item.parent.name === 'body') {
-        $(item).wrap('<div></div>')
-      }
-    })
-
-    // --------------------------------
     // Escape mustache expresions
     // --------------------------------
 


### PR DESCRIPTION
As noted in #4524 there are an excess of div wrappers in generated page html.

This PR removes this code section because it seems that standalone text is already wrapped in paragraph elements, making this superfluous and simultaneously correcting the issue of excess div wrappers.

Closes #4524