### PR TITLE
Hide footnotes keyline when preceded by header

### DIFF
--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -77,6 +77,10 @@
     & + h2, & + h3, & + h4, & + h5, & + h6 {
       margin-top: 8px;
     }
+    
+    & + hr.footnotes-sep {
+      display: none;
+    }
   }
 
   h1 {


### PR DESCRIPTION
Since we're provided base styles to work "out of the box", we should consider edge cases such as this where footnotes always show their own keyline, even when preceded by a Header (which is styled with a keyline underneath)

This PR hides key-lines created by `markdown-it-footnote` template when footnotes are directly preceded by header, but leaves them in place when the footnotes follow regular Phrasing content.

Examples:
```md
# References
[^1]: Shows no key-line because References header has one already

# New Page
Text goes here and whatever else

[^1]: these footnotes are not directly preceded by a header, but a paragraph and WILL show a key-line
```
