### PR TITLE
Updated values file to imagePullPolicy to match what is in templates/deployment.yaml

### DIFF
--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: requarks/wiki
-  pullPolicy: IfNotPresent
+  imagePullPolicy: IfNotPresent
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This fix will allow people to correctly set the image pull policy from the values file when running wiki.js in kubernetes.

Currently setting the value does not get picked up, it always uses the default of **IfNotPresent**. Users may want to set **Always** OR **Never** but would need to change the helm chart.

This is the deployment.yaml line in code we are updating to match: 

https://github.com/wjkw1/wiki/blob/dev/dev/helm/templates/deployment.yaml#L29
