### PR TITLE
fibers is not compatible with node 16.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "homepage": "https://github.com/Requarks/wiki#readme",
   "engines": {
-    "node": ">=10.12"
+    "node": ">=10.12 <16"
   },
   "dependencies": {
     "@azure/storage-blob": "12.2.1",


### PR DESCRIPTION
See https://github.com/laverdet/node-fibers readme:

  Update [April 13th, 2021] -- Fibers is not compatible with nodejs v16.0.0 or
  later. Unfortunately, v8 commit dacc2fee0f is a breaking change and
  workarounds are non-trivial.

This change modifies `package.json` to restrict `yarn dev` from running in node >=16.

I'm not sure where the documentation at https://docs.requarks.io/dev lives; it doesn't appear to be in this repo, but it should probably also be updated to reflect this.