### PR TITLE
Update Dockerfile: set VOLUME to /wiki/data

### DIFF
--- a/dev/build/Dockerfile
+++ b/dev/build/Dockerfile
@@ -44,7 +44,7 @@ COPY --chown=node:node ./LICENSE ./LICENSE
 
 USER node
 
-VOLUME ["/wiki/data/content"]
+VOLUME ["/wiki/data"]
 
 EXPOSE 3000
 EXPOSE 3443


### PR DESCRIPTION
By this you can prevent issues like [#5](https://github.com/linuxserver/docker-wikijs/issues/5) with access rights to eg. /wiki/data/cache

