### PR TITLE
update Dockerfile: set python to python3

### DIFF
--- a/dev/build/Dockerfile
+++ b/dev/build/Dockerfile
@@ -3,7 +3,7 @@
 # ====================
 FROM node:14-alpine AS assets
 
-RUN apk add yarn g++ make python --no-cache
+RUN apk add yarn g++ make python3 --no-cache
 
 WORKDIR /wiki
 


### PR DESCRIPTION
When I'm ready to use the dockerfile to build the image
An error has occurred, like this:

ERROR: unable to select packages:
  python (no such package):
    required by: world[python]

And then I go to the address source and I find the python3 package after that, but there's no python2 package before that

