### PR TITLE
Introduce volumes and volumeMounts chart values

### DIFF
--- a/dev/helm/README.md
+++ b/dev/helm/README.md
@@ -104,6 +104,8 @@ The following table lists the configurable parameters of the Wiki.js chart and t
 | `affinity`                       | Affinity settings for wiki.js pod assignment    | `{}`                                                       |
 | `schedulerName`                  | Name of an alternate scheduler for wiki.js pod  | `nil`                                                      |
 | `tolerations`                    | Toleration labels for wiki.jsk pod assignment    | `[]`                                                       |
+| `volumeMounts`                   | Volume mounts for Wiki.js container              | `[]`                                                       |
+| `volumes`                        | Volumes for Wiki.js Pod                          | `[]`                                                       |
 | `ingress.enabled`                    | Enable ingress controller resource          | `false`                                                    |
 | `ingress.annotations`                | Ingress annotations                         | `{}`                                                       |
 | `ingress.hosts`                      | List of ingress rules                        | `[{"host": "wiki.local", "paths": ["/"]}]`                |

--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -63,6 +63,10 @@ spec:
                   key: {{ template "wiki.postgresql.secretKey" . }}
             - name: HA_ACTIVE
               value: {{ .Values.replicaCount | int | le 2 | quote }}
+    {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+    {{- end }}
           ports:
             - name: http
               containerPort: 3000
@@ -83,5 +87,9 @@ spec:
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.volumes }}
+      volumes:
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -85,6 +85,10 @@ tolerations: []
 
 affinity: {}
 
+volumeMounts: []
+
+volumes: []
+
 # This will allow us to install locales even without internet access using a initContainer & wikjs "sideloading"
 sideload:
   enabled: false


### PR DESCRIPTION
# Description

This PR aims at making possible to add extra volumes and extra volumes mounts in Wiki.js container. It is really useful to add CA certificates in /etc/ssl/certs for instance.

# Test

Deploy the chart with these values and check the mount in the Wiki.js container.

```yaml
[...]

volumeMounts:
  - name: my-volume
    mountPath: /mydir
    readOnly: true
volumes:
  - name: my-volume
    hostPath:
      path: /mydir
```