### PR TITLE
fix: Remove wild log that was possibly for debugging

### DIFF
--- a/server/models/users.js
+++ b/server/models/users.js
@@ -346,7 +346,6 @@ module.exports = class User extends Model {
         }
       }
     }
-    console.info(redirect)
 
     // Is 2FA required?
     if (!skipTFA) {


### PR DESCRIPTION
Every time a user logged in, a log containing only `/` was emitted outside of any configured logging. I could instead log this with an actual logger, but that might be unnecessary given the content.