### PR TITLE
Add an example of underline

### DIFF
--- a/client/components/editor/markdown/help.vue
+++ b/client/components/editor/markdown/help.vue
@@ -31,6 +31,17 @@
                   v-card.editor-markdown-help-result(flat)
                     v-card-text
                       .caption: em Lorem ipsum
+              .body-2.mt-3 Underline
+              v-layout(row)
+                v-flex(xs6)
+                  v-card.editor-markdown-help-source(flat)
+                    v-card-text
+                      div _Lorem ipsum_
+                v-icon mdi-chevron-right
+                v-flex
+                  v-card.editor-markdown-help-result(flat)
+                    v-card-text
+                      .caption(style='text-decoration: underline;') Lorem ipsum
               .body-2.mt-3 Strikethrough
               v-layout(row)
                 v-flex(xs6)


### PR DESCRIPTION
I have found out that `_underline_` resulting in _underline_ is supported, but not documented in the help.

So I have added this to the help page code by copy-pasting and altering corresponding sections, i.e. I have not tested the PR. Please let me know if it is needed, and if there is a corresponding guide that would assist in testing.