### PR TITLE
Multi ldpa strategies Issue #2554

### DIFF
--- a/server/core/auth.js
+++ b/server/core/auth.js
@@ -82,6 +82,7 @@ module.exports = {
           const strategy = require(`../modules/authentication/${stg.strategyKey}/authentication.js`)
 
           stg.config.callbackURL = `${WIKI.config.host}/login/${stg.key}/callback`
+          stg.config.key = stg.key;
           strategy.init(passport, stg.config)
           strategy.config = stg.config
 

--- a/server/models/users.js
+++ b/server/models/users.js
@@ -308,7 +308,7 @@ module.exports = class User extends Model {
 
       // Authenticate
       return new Promise((resolve, reject) => {
-        WIKI.auth.passport.authenticate(selStrategy.strategyKey, {
+        WIKI.auth.passport.authenticate(selStrategy.key, {
           session: !strInfo.useForm,
           scope: strInfo.scopes ? strInfo.scopes : null
         }, async (err, user, info) => {

--- a/server/modules/authentication/ldap/authentication.js
+++ b/server/modules/authentication/ldap/authentication.js
@@ -10,7 +10,7 @@ const _ = require('lodash')
 
 module.exports = {
   init (passport, conf) {
-    passport.use('ldap',
+    passport.use(conf.key,
       new LdapStrategy({
         server: {
           url: conf.url,


### PR DESCRIPTION
I fixed it. The main problem was in file:

_server/modules/authentication/ldap/authentication.js_

Every LDAP strategy has the same name in the strategy list (look at line 13) so only the last added one will work.

How I fixed it:

1.  Open file _server/core/auth.js_
2.  Add `stg.config.key = stg.key;` after line 84.
3. Open file _server/modules/authentication/ldap/authentication.js_
4. Replace line 13 with `passport.use(conf.key,`
5. Open file _server/models/users.js_
6. Replace line 311 with `WIKI.auth.passport.authenticate(selStrategy.key, {`