### PR TITLE
Login page logo issue

### DIFF
--- a/client/components/login.vue
+++ b/client/components/login.vue
@@ -4,7 +4,7 @@
       .login-sd
         .d-flex.mb-5
           .login-logo
-            v-avatar(tile, size='34')
+            v-avatar(tile, size='44')
               v-img(:src='logoUrl')
           .login-title
             .text-h6.grey--text.text--darken-4 {{ siteTitle }}
@@ -723,8 +723,8 @@ export default {
       padding: 12px 0 0 12px;
       width: 58px;
       height: 58px;
-      background-color: #222;
-      margin-left: 12px;
+      // background-color: #222;
+      // margin-left: 12px;
       border-bottom-left-radius: 7px;
       border-bottom-right-radius: 7px;
     }
@@ -732,6 +732,7 @@ export default {
     &-title {
       height: 58px;
       padding-left: 12px;
+      padding-top: 8px;
       display: flex;
       align-items: center;
       text-shadow: .5px .5px #FFF;


### PR DESCRIPTION
Issue: 
There is black background in the login screen logo and the logo is very small.

Fix
Increased the logo size.
Remove the background color from the image.
Remove the margin-left CSS. 

Please associate this PR with issue #5155 