### PR TITLE
feat: Added lightbox/modal support for image preview

### DIFF
--- a/client/components/editor/editor-code.vue
+++ b/client/components/editor/editor-code.vue
@@ -233,6 +233,9 @@ export default {
           if (opts.align && opts.align !== '') {
             img += ` class="align-${opts.align}"`
           }
+          if (opts.className && opts.className !== '') {
+            img += ` class="align-${opts.className}"`
+          }
           img += ` />`
           this.insertAtCursor({
             content: img

--- a/client/components/editor/editor-markdown.vue
+++ b/client/components/editor/editor-markdown.vue
@@ -849,6 +849,9 @@ export default {
           if (opts.align && opts.align !== '') {
             img += `{.align-${opts.align}}`
           }
+          if (opts.className && opts.className !== '') {
+            img += `{.${opts.className}}`
+          }
           this.insertAtCursor({
             content: img
           })

--- a/client/components/editor/editor-modal-media.vue
+++ b/client/components/editor/editor-modal-media.vue
@@ -188,6 +188,18 @@
                 placeholder='None'
               )
 
+          v-card.mt-3.radius-7.animated.fadeInRight.wait-p4s(:light='!$vuetify.theme.dark', :dark='$vuetify.theme.dark')
+            v-card-text.pb-0
+              v-toolbar.radius-7(:color='$vuetify.theme.dark ? `teal` : `teal lighten-5`', dense, flat)
+                .body-2(:class='$vuetify.theme.dark ? `white--text` : `teal--text`') Custom class name
+              v-text-field.mt-3(
+                v-model='imageClass'
+                outlined
+                single-line
+                color='teal'
+                placeholder='None'
+              )
+
     //- RENAME DIALOG
 
     v-dialog(v-model='renameDialog', max-width='550', persistent)
@@ -269,6 +281,7 @@ export default {
         { text: 'Absolute Top Right', value: 'abstopright' }
       ],
       imageAlignment: '',
+      imageClass: '',
       loading: false,
       newFolderDialog: false,
       newFolderName: '',
@@ -375,7 +388,8 @@ export default {
         kind: asset.kind,
         path: this.currentFolderId > 0 ? `/${assetPath}/${asset.filename}` : `/${asset.filename}`,
         text: asset.filename,
-        align: this.imageAlignment
+        align: this.imageAlignment,
+        className: this.imageClass
       })
       this.activeModal = ''
     },

--- a/client/helpers/modal.js
+++ b/client/helpers/modal.js
@@ -1,0 +1,36 @@
+window.onload = function() {
+  const lightboxImages = window.document.querySelectorAll('.modal')
+
+  lightboxImages.forEach(img => {
+    img.addEventListener('click', e => {
+      e.preventDefault()
+
+      const imageContainer = document.createElement('div')
+      imageContainer.classList.add('image-modal-popup')
+
+      const closeButton = document.createElement('div')
+      closeButton.className = ('image-modal-popup-close')
+      closeButton.innerHTML = '<i aria-hidden="true" class="v-icon notranslate mdi mdi-close"></i>'
+      closeButton.setAttribute('data-img', img.href)
+
+      const image = document.createElement('img')
+
+      let href = img.href
+      if (!href) {
+        href = img.getAttribute('src')
+      }
+
+      image.src = href
+      image.classList.add('modal-image')
+
+      imageContainer.appendChild(image)
+      imageContainer.appendChild(closeButton)
+
+      imageContainer.addEventListener('click', function handleClick(event) {
+        imageContainer.remove()
+      })
+
+      document.querySelector('.v-main').appendChild(imageContainer)
+    })
+  })
+}

--- a/client/index-app.js
+++ b/client/index-app.js
@@ -22,5 +22,6 @@ import(/* webpackChunkName: "theme" */ './themes/' + siteConfig.theme + '/scss/a
 import(/* webpackChunkName: "mdi" */ '@mdi/font/css/materialdesignicons.css')
 
 require('./helpers/compatibility.js')
+require('./helpers/modal.js')
 require('./client-app.js')
 import(/* webpackChunkName: "theme" */ './themes/' + siteConfig.theme + '/js/app.js')

--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -1037,3 +1037,70 @@
     display: none;
   }
 }
+
+
+/* style for demo purposes   */
+* {
+  margin: 0;
+  padding: 0;
+  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
+}
+
+/* modal popup styles */
+.image-modal-popup {
+  position: fixed;
+  overflow: auto;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  animation: 500ms fadeIn;
+  width: 100vw;
+  height: 100vh;
+  z-index: 9999;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 30px;
+
+  > img {
+    width: auto;
+    max-width: 100%;
+    max-height: 100%;
+    height: auto;
+    margin-bottom: 10px;
+    cursor: pointer;
+  }
+
+  &-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: #fff;
+    color: #000;
+    font-size: 18px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 32px;
+    height: 32px;
+    line-height: 1;
+    border-radius: 50%;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+// toggle class for modal
+.modal {
+  cursor: pointer;
+}


### PR DESCRIPTION
Add a simple "modal" class to images from the assets dialog and enable a modal window for preview.  Clicking on the modal window will close it.

 

Example for a thumbnail preview with a clickable image

```
[![title](/example.jpg =300x)](/example.jpg){.modal}
```

or regular inserted image
```
![example.jpg](/example.jpg){.align-center}{.modal}
```