### PR TITLE
Solving issue #5200

### DIFF
--- a/server/controllers/common.js
+++ b/server/controllers/common.js
@@ -525,8 +525,8 @@ router.get('/*', async (req, res, next) => {
           }
 
           // -> Inject comments variables
-          const shouldDisplayComments = WIKI.config.features.featurePageComments;
-          let commentTmpl = shouldDisplayComments ? {
+          const shouldDisplayComments = WIKI.config.features.featurePageComments
+          const commentTmpl = shouldDisplayComments ? {
             codeTemplate: WIKI.data.commentProvider.codeTemplate,
             head: WIKI.data.commentProvider.head,
             body: WIKI.data.commentProvider.body,

--- a/server/controllers/common.js
+++ b/server/controllers/common.js
@@ -525,8 +525,8 @@ router.get('/*', async (req, res, next) => {
           }
 
           // -> Inject comments variables
-          const shouldDisplayComments = WIKI.config.features.featurePageComments && WIKI.data.commentProvider.codeTemplate
-          const commentTmpl = shouldDisplayComments ? {
+          const shouldDisplayComments = WIKI.config.features.featurePageComments;
+          let commentTmpl = shouldDisplayComments ? {
             codeTemplate: WIKI.data.commentProvider.codeTemplate,
             head: WIKI.data.commentProvider.head,
             body: WIKI.data.commentProvider.body,


### PR DESCRIPTION
Comments stoped working in version 2.5.278 (#5200). This patch returns comments funcionallity. Tested with Default Comments, Disqus Comments, both with the "Do not allow comments" option turned on and off.

