### PR TITLE
fix: git storage does not sync files with unicode

### DIFF
--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -45,6 +45,10 @@ module.exports = {
       await this.git.init()
     }
 
+    // Disable quotePath
+    // Link https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath
+    await this.git.raw(['config', '--local', 'core.quotepath', false])
+
     // Set default author
     await this.git.raw(['config', '--local', 'user.email', this.config.defaultEmail])
     await this.git.raw(['config', '--local', 'user.name', this.config.defaultName])


### PR DESCRIPTION
git has the quotopath option enabled by default, filepaths with unicode characters will be escaped, causing the wiki to not handle changes.

As shown below, the changed file is the Chinese file name "你好"

![image](https://user-images.githubusercontent.com/13045857/167353582-b0c5e139-b37e-4704-adb2-1a00af5e26f4.png)