### PR TITLE
fix: users unable to authenticate with twitch auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "passport-openidconnect": "0.0.2",
     "passport-saml": "3.2.1",
     "passport-slack-oauth2": "1.1.1",
-    "passport-twitch-oauth": "1.0.0",
+    "passport-twitch-strategy": "2.2.0",
     "pem-jwk": "2.0.0",
     "pg": "8.4.1",
     "pg-hstore": "2.3.4",

--- a/server/modules/authentication/twitch/authentication.js
+++ b/server/modules/authentication/twitch/authentication.js
@@ -4,7 +4,7 @@
 // Twitch Account
 // ------------------------------------
 
-const TwitchStrategy = require('passport-twitch-oauth').Strategy
+const TwitchStrategy = require('passport-twitch-strategy').Strategy
 const _ = require('lodash')
 
 module.exports = {
@@ -21,7 +21,7 @@ module.exports = {
             providerKey: req.params.strategy,
             profile: {
               ...profile,
-              picture: _.get(profile, 'avatar', '')
+              picture: _.get(profile, 'profile_image_url', '')
             }
           })
           cb(null, user)

--- a/yarn.lock
+++ b/yarn.lock
@@ -14697,7 +14697,7 @@ passport-oauth2@1.6.1, passport-oauth2@^1.6.0:
     uid2 "0.0.x"
     utils-merge "1.x.x"
 
-passport-oauth2@1.x.x, passport-oauth2@^1.2.0, passport-oauth2@^1.4.0, passport-oauth2@^1.5.0:
+passport-oauth2@1.x.x, passport-oauth2@^1.4.0, passport-oauth2@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/passport-oauth2/-/passport-oauth2-1.5.0.tgz#64babbb54ac46a4dcab35e7f266ed5294e3c4108"
   integrity sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==
@@ -14761,12 +14761,13 @@ passport-strategy@1.x.x, passport-strategy@^1.0.0:
   resolved "https://registry.yarnpkg.com/passport-strategy/-/passport-strategy-1.0.0.tgz#b5539aa8fc225a3d1ad179476ddf236b440f52e4"
   integrity sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ=
 
-passport-twitch-oauth@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/passport-twitch-oauth/-/passport-twitch-oauth-1.0.0.tgz#8ba20658ffe18dbeab2201547e0a2e6a459adaf1"
-  integrity sha512-sX/HZgRP320CICi+ZQn0MpKV8PiVcxuEOaLywOE2EiXQkkUm4glTgBbz9bsr7Ws7985fFmP+LgLIe0/HtMGucw==
+passport-twitch-strategy@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/passport-twitch-strategy/-/passport-twitch-strategy-2.2.0.tgz#8a9d78ef478de92d1164fa8d194ee76ff551e0f1"
+  integrity sha512-PjESpFVnJk6GIX2EOtkuyk01K81ACDG8IiLJu6yOtOyaMti24/afMtqBcqDrsKqz0RHrx206AfWcI6Q4Tvy4OQ==
   dependencies:
-    passport-oauth2 "^1.2.0"
+    node-fetch "^2.6.1"
+    passport-oauth2 "^1.5.0"
 
 passport@0.4.1, passport@^0.4.1:
   version "0.4.1"


### PR DESCRIPTION
This fixes the Twitch auth strategy which currently displays "Oops, something went wrong...Failed to fetch user profile" when users attempt to authenticate. 

### Cause
On May 1 2021, [Twitch began requiring a "Client-Id" header for all Helix API calls](https://discuss.dev.twitch.tv/t/requiring-oauth-for-helix-twitch-api-endpoints/23916). The current Twitch passport strategy package (`passport-twitch-oauth`) has not been updated to account for this, thus its `/users` call to the Twitch API always fails. 

Code in question: https://github.com/mattgaunt/passport-twitch/blob/master/lib/strategy.js#L75-L76

### Proposed Fix
Given the `passport-twitch-oauth` package has not received any updates for 4 years since it's initial 1.0 release, I opted to move to a more maintained package instead of trying to submit a fix to the current one. After some searching, [passport-twitch-strategy](https://www.npmjs.com/package/passport-twitch-strategy) appeared to be the best option out there right now. 

The only code that needed to be updated to account for the strategy change was the `picture` property as this new strategy passes along Twitch response data as-is instead of mapping it.

### Testing
Setup a twitch auth in local dev environment and ensured I was able to successfully authenticate 
![May-11-2022 03-45-23](https://user-images.githubusercontent.com/3515161/167808855-392c05c8-e067-4253-b1a4-ebd22862cd18.gif)

