### PR TITLE
fix: search result display as empty

### DIFF
--- a/client/components/common/search-results.vue
+++ b/client/components/common/search-results.vue
@@ -14,7 +14,7 @@
       .search-results-none(v-else-if='!searchIsLoading && (!results || results.length < 1)')
         img(src='/_assets/svg/icon-no-results.svg', alt='No Results')
         .subheading {{$t('common:header.searchNoResult')}}
-      template(v-if='results && results.length > 0')
+      template(v-if='search && search.length >= 2 && results && results.length > 0')
         v-subheader.white--text {{$t('common:header.searchResultsCount', { total: response.totalHits })}}
         v-list.search-results-items.radius-7.py-0(two-line, dense)
           template(v-for='(item, idx) of results')
@@ -101,8 +101,6 @@ export default {
     search(newValue, oldValue) {
       this.cursor = 0
       if (!newValue || (newValue && newValue.length < 2)) {
-        this.response.results = []
-        this.response.suggestions = []
         this.searchIsLoading = false
       } else {
         this.searchIsLoading = true


### PR DESCRIPTION
When clearing the search keyword and re-input, the search results are display as empty
After modifying response.result, the value is always the empty.
It maybe related to the apollo client result cache, response.result cannot be
modified.

![录屏_选择区域_20220512153721](https://user-images.githubusercontent.com/13045857/168017613-1b8c928d-cfa4-4876-897e-0863b7999006.gif)
