### PR TITLE
fix: changed spelling of Kiev to Kyiv

### DIFF
--- a/client/components/admin/admin-users-edit.vue
+++ b/client/components/admin/admin-users-edit.vue
@@ -558,7 +558,7 @@ export default {
         { text: '(GMT+02:00) Jerusalem', value: 'Asia/Jerusalem' },
         { text: '(GMT+02:00) Johannesburg', value: 'Africa/Johannesburg' },
         { text: '(GMT+02:00) Khartoum', value: 'Africa/Khartoum' },
-        { text: '(GMT+02:00) Kiev', value: 'Europe/Kiev' },
+        { text: '(GMT+02:00) Kyiv', value: 'Europe/Kyiv' },
         { text: '(GMT+02:00) Maputo', value: 'Africa/Maputo' },
         { text: '(GMT+02:00) Moscow-01 - Kaliningrad', value: 'Europe/Kaliningrad' },
         { text: '(GMT+02:00) Nicosia', value: 'Asia/Nicosia' },

--- a/client/components/profile/profile.vue
+++ b/client/components/profile/profile.vue
@@ -528,7 +528,7 @@ export default {
         { text: '(GMT+02:00) Jerusalem', value: 'Asia/Jerusalem' },
         { text: '(GMT+02:00) Johannesburg', value: 'Africa/Johannesburg' },
         { text: '(GMT+02:00) Khartoum', value: 'Africa/Khartoum' },
-        { text: '(GMT+02:00) Kiev', value: 'Europe/Kiev' },
+        { text: '(GMT+02:00) Kyiv', value: 'Europe/Kyiv' },
         { text: '(GMT+02:00) Maputo', value: 'Africa/Maputo' },
         { text: '(GMT+02:00) Moscow-01 - Kaliningrad', value: 'Europe/Kaliningrad' },
         { text: '(GMT+02:00) Nicosia', value: 'Asia/Nicosia' },


### PR DESCRIPTION
Kiev is a Russian style of spelling. The proper and government official way is Kyv.
More details is available [there](https://en.wikipedia.org/wiki/KyivNotKiev).