### PR TITLE
saml auth: `authnContext` must be a list now

### DIFF
--- a/server/modules/authentication/saml/authentication.js
+++ b/server/modules/authentication/saml/authentication.js
@@ -21,7 +21,7 @@ module.exports = {
       wantAssertionsSigned: conf.wantAssertionsSigned,
       acceptedClockSkewMs: _.toSafeInteger(conf.acceptedClockSkewMs),
       disableRequestedAuthnContext: conf.disableRequestedAuthnContext,
-      authnContext: [conf.authnContext],
+      authnContext: _.split(conf.authnContext, '|'),
       racComparison: conf.racComparison,
       forceAuthn: conf.forceAuthn,
       passive: conf.passive,

--- a/server/modules/authentication/saml/authentication.js
+++ b/server/modules/authentication/saml/authentication.js
@@ -21,7 +21,7 @@ module.exports = {
       wantAssertionsSigned: conf.wantAssertionsSigned,
       acceptedClockSkewMs: _.toSafeInteger(conf.acceptedClockSkewMs),
       disableRequestedAuthnContext: conf.disableRequestedAuthnContext,
-      authnContext: conf.authnContext,
+      authnContext: [conf.authnContext],
       racComparison: conf.racComparison,
       forceAuthn: conf.forceAuthn,
       passive: conf.passive,


### PR DESCRIPTION
This fixes

    this.options.authnContext.forEach is not a function

when trying to login via SAML on wiki-js 2.5.281.

Reason for that is that `authnContext` must be a list now which is
apparently a breaking change that was missed while upgrading
passport-saml[1].

Resolves #5289

[1] https://github.com/node-saml/passport-saml/pull/615

cc @NGPixel 

