### PR TITLE
Enable youtube and vimeo media players

### DIFF
--- a/server/modules/rendering/html-mediaplayers/renderer.js
+++ b/server/modules/rendering/html-mediaplayers/renderer.js
@@ -1,5 +1,26 @@
+const rxYoutube = /^.*(?:(?:youtu\.be\/|v\/|vi\/|u\/\w\/|embed\/)|(?:(?:watch)?\?v(?:i)?=|&v(?:i)?=))([^#&?]*).*/
+const rxVimeo = /^.*(vimeo\.com\/)((channels\/[A-z]+\/)|(groups\/[A-z]+\/videos\/))?([0-9]+)/
+
 module.exports = {
   init($, config) {
-
+    $('oembed').each((i, elm) => {
+      const url = $(elm).attr('url')
+      const ytMatch = url.match(rxYoutube)
+      let src
+      if (ytMatch) {
+        src = `https://www.youtube.com/embed/${ytMatch[1]}`
+      } else {
+        const vmMatch = url.match(rxVimeo)
+        if (vmMatch) {
+          src = `https://player.vimeo.com/video/${vmMatch[5]}`
+        } else {
+          return
+        }
+      }
+      const newElm = $(`<div class="video-responsive">
+        <iframe type="text/html" width="640" height="360" src="${src}" frameborder="0" allowfullscreen></iframe>
+      </div>`)
+      $(elm).parent().replaceWith(newElm)
+    })
   }
 }

--- a/server/modules/rendering/html-security/renderer.js
+++ b/server/modules/rendering/html-security/renderer.js
@@ -29,7 +29,7 @@ module.exports = {
 
       if (config.allowIFrames) {
         allowedTags.push('iframe')
-        allowedAttrs.push('allow')
+        allowedAttrs.push('allow', 'frameborder', 'allowfullscreen')
       }
 
       input = DOMPurify.sanitize(input, {


### PR DESCRIPTION
Currently inserted media is sanitized away. 
When inserting media using the visual editor and html sanitation is turned off only an `oembed` tag is added. 

Based on an [existing workaround](https://github.com/requarks/wiki/discussions/5043#discussioncomment-2787614) I'm letting the `html-mediaplayers` module replace the `oembed` with an youtube or vimeo ready `iframe` when it's a youtube or vimeo video.  
I've also added a few common iframe attributes to the html-security module, like `allowfullscreen`. 

This change will still require people to enable "Allow iframes", which might be a bit confusing.

This is probably far from the perfect solution but let's get the ball rolling, please let me know what to improve. 