### PR TITLE
Load self-signed CA from file as described in the helm chart

### DIFF
--- a/server/core/db.js
+++ b/server/core/db.js
@@ -60,17 +60,13 @@ module.exports = {
       sslOptions = true
     }
 
-    // Handle inline SSL CA Certificate mode
+    // Handle self-signed CA file
+    // https://node-postgres.com/features/ssl
     if (!_.isEmpty(process.env.DB_SSL_CA)) {
-      const chunks = []
-      for (let i = 0, charsLength = process.env.DB_SSL_CA.length; i < charsLength; i += 64) {
-        chunks.push(process.env.DB_SSL_CA.substring(i, i + 64))
-      }
-
       dbUseSSL = true
       sslOptions = {
-        rejectUnauthorized: true,
-        ca: '-----BEGIN CERTIFICATE-----\n' + chunks.join('\n') + '\n-----END CERTIFICATE-----\n'
+        rejectUnauthorized: false,
+        ca: fs.readFileSync(process.env.DB_SSL_CA).toString(),
       }
     }
 


### PR DESCRIPTION
The helm chart supports [`postgresql.ca`](https://github.com/requarks/wiki/blob/main/dev/helm/values.yaml#L120) for setting self-signed CA's for postgres connections, though when trying this i noticed that the servers database logic handles this differently.

It would load a CA from a concatenated string, which i also tried, but this also didn't work, as it would still set `rejectUnauthorized: true`, thereby disalllowing self-signed CA certificates. 

If you're CA would be signed by a root CA, there would be no need to set a CA in the first place, so i guess this logic never worked?

With this pull request, the `DB_SSL_CA` logic now corresponds to the descriptions in the helm chart.
