### PR TITLE
Fix sidebar root title by not overiding it when translation isn't yet available

### DIFF
--- a/client/themes/default/components/nav-sidebar.vue
+++ b/client/themes/default/components/nav-sidebar.vue
@@ -49,7 +49,7 @@
         v-list-item(v-for='(item, idx) of parents', :key='`parent-` + item.id', @click='fetchBrowseItems(item)', style='min-height: 30px;')
           v-list-item-avatar(size='18', :style='`padding-left: ` + (idx * 8) + `px; width: auto; margin: 0 5px 0 0;`')
             v-icon(small) mdi-folder-open
-          v-list-item-title {{ item.title }}
+          v-list-item-title {{ idx === 0 ? $t('common:sidebar.root') : item.title }}
         v-divider.mt-2
         v-list-item.mt-2(v-if='currentParent.pageId > 0', :href='`/` + currentParent.locale + `/` + currentParent.path', :key='`directorypage-` + currentParent.id', :input-value='path === currentParent.path')
           v-list-item-avatar(size='24')


### PR DESCRIPTION
Fixes: https://github.com/requarks/wiki/discussions/4888

Before:
![Screenshot before@2x](https://user-images.githubusercontent.com/523210/170263154-3b6a326c-a538-447c-9a35-e0e6fb4697ba.png)
After:
![Screenshot after@2x](https://user-images.githubusercontent.com/523210/170263189-4a54cc9b-31b6-4f8e-80a2-a32810c91a5c.png)

I'm not sure why but the root parent's title is being overriden with a translatable title. But this happens in the mount handler when the translation isn't yet available, causing it to fallback to the text "sidebar.root". 