### PR TITLE
fix: don't push files to git if ignored

### DIFF
--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -314,7 +314,7 @@ module.exports = {
     const gitFilePath = `./${fileName}`
     if ((await this.git.checkIgnore(gitFilePath)).length === 0) {
       await this.git.add(gitFilePath)
-      await this.git.commit(`docs: create ${page.path}`, fileName, {
+      await this.git.commit(`docs: update ${page.path}`, fileName, {
         '--author': `"${page.authorName} <${page.authorEmail}>"`
       })
     }

--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -289,9 +289,9 @@ module.exports = {
     const filePath = path.join(this.repoPath, fileName)
     await fs.outputFile(filePath, page.injectMetadata(), 'utf8')
 
-    const gitPath = `./${fileName}`
-    if ((await this.git.checkIgnore(gitPath)).length === 0) {
-      await this.git.add(gitPath)
+    const gitFilePath = `./${fileName}`
+    if ((await this.git.checkIgnore(gitFilePath)).length === 0) {
+      await this.git.add(gitFilePath)
       await this.git.commit(`docs: create ${page.path}`, fileName, {
         '--author': `"${page.authorName} <${page.authorEmail}>"`
       })
@@ -311,9 +311,9 @@ module.exports = {
     const filePath = path.join(this.repoPath, fileName)
     await fs.outputFile(filePath, page.injectMetadata(), 'utf8')
 
-    const gitPath = `./${fileName}`
-    if ((await this.git.checkIgnore(gitPath)).length === 0) {
-      await this.git.add(gitPath)
+    const gitFilePath = `./${fileName}`
+    if ((await this.git.checkIgnore(gitFilePath)).length === 0) {
+      await this.git.add(gitFilePath)
       await this.git.commit(`docs: create ${page.path}`, fileName, {
         '--author': `"${page.authorName} <${page.authorEmail}>"`
       })
@@ -331,9 +331,9 @@ module.exports = {
       fileName = `${page.localeCode}/${fileName}`
     }
 
-    const gitPath = `./${fileName}`
-    if ((await this.git.checkIgnore(gitPath)).length === 0) {
-      await this.git.rm(gitPath)
+    const gitFilePath = `./${fileName}`
+    if ((await this.git.checkIgnore(gitFilePath)).length === 0) {
+      await this.git.rm(gitFilePath)
       await this.git.commit(`docs: delete ${page.path}`, fileName, {
         '--author': `"${page.authorName} <${page.authorEmail}>"`
       })

--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -289,10 +289,13 @@ module.exports = {
     const filePath = path.join(this.repoPath, fileName)
     await fs.outputFile(filePath, page.injectMetadata(), 'utf8')
 
-    await this.git.add(`./${fileName}`)
-    await this.git.commit(`docs: create ${page.path}`, fileName, {
-      '--author': `"${page.authorName} <${page.authorEmail}>"`
-    })
+    const gitPath = `./${fileName}`
+    if ((await this.git.checkIgnore(gitPath)).length === 0) {
+      await this.git.add(gitPath)
+      await this.git.commit(`docs: create ${page.path}`, fileName, {
+        '--author': `"${page.authorName} <${page.authorEmail}>"`
+      })
+    }
   },
   /**
    * UPDATE
@@ -308,10 +311,13 @@ module.exports = {
     const filePath = path.join(this.repoPath, fileName)
     await fs.outputFile(filePath, page.injectMetadata(), 'utf8')
 
-    await this.git.add(`./${fileName}`)
-    await this.git.commit(`docs: update ${page.path}`, fileName, {
-      '--author': `"${page.authorName} <${page.authorEmail}>"`
-    })
+    const gitPath = `./${fileName}`
+    if ((await this.git.checkIgnore(gitPath)).length === 0) {
+      await this.git.add(gitPath)
+      await this.git.commit(`docs: create ${page.path}`, fileName, {
+        '--author': `"${page.authorName} <${page.authorEmail}>"`
+      })
+    }
   },
   /**
    * DELETE
@@ -325,10 +331,13 @@ module.exports = {
       fileName = `${page.localeCode}/${fileName}`
     }
 
-    await this.git.rm(`./${fileName}`)
-    await this.git.commit(`docs: delete ${page.path}`, fileName, {
-      '--author': `"${page.authorName} <${page.authorEmail}>"`
-    })
+    const gitPath = `./${fileName}`
+    if ((await this.git.checkIgnore(gitPath)).length === 0) {
+      await this.git.rm(gitPath)
+      await this.git.commit(`docs: delete ${page.path}`, fileName, {
+        '--author': `"${page.authorName} <${page.authorEmail}>"`
+      })
+    }
   },
   /**
    * RENAME


### PR DESCRIPTION
This was an edge case we ran into wanting to keep internal documentation off our synced git storage. This change allows us to maintain our own gitignore file to exclude files from git storage and still sync them to other storage backends.