### PR TITLE
Added head and body injection to editor template.

### DIFF
--- a/server/views/editor.pug
+++ b/server/views/editor.pug
@@ -3,6 +3,8 @@ extends master.pug
 block head
   if injectCode.css
     style(type='text/css')!= injectCode.css
+  if injectCode.head
+    != injectCode.head
 
 block body
   #root
@@ -24,3 +26,5 @@ block body
       checkout-date=page.updatedAt
       effective-permissions=Buffer.from(JSON.stringify(effectivePermissions)).toString('base64')
       )
+  if injectCode.body
+    != injectCode.body


### PR DESCRIPTION
I've added head and body injection to the editor template, so that the preview for the page shows custom web components / page extensions that have been injected into the extra head / extra body portion of the settings.

## Use Case

Since there isn't currently any kind of plugin or extension system, I decided to write some custom html components (i.e. images with captions/details sections, custom symbols for rpg dice results, etc) to wrap up what was turning into a bit of a nightmare of custom style + copy/pasting boilerplate html all over the place. Using web components turned out to be really easy, as I just have to add a `.css` and `.js` file into the head of my wiki, and then the custom components work great (especially the shadow dom style encapsulation). Except, none of the custom markup renders in the preview.

The fix seemed simple enough, and adds a very nice vector for extending wiki.js, imho.

## Questions

* Are there any concerns with this? I couldn't really think of any that wouldn't be obvious and fixable?
* Should we also add this to pages like history/admin?
* Should, maybe, this be a set of options where you can turn on/off which page templates get this injection? (That feels like overkill, imho.)