### PR TITLE
fix: search cleared on enter

### DIFF
--- a/client/components/common/search-results.vue
+++ b/client/components/common/search-results.vue
@@ -117,14 +117,12 @@ export default {
       }
     })
     this.$root.$on('searchEnter', () => {
-      if (!this.results) {
-        return
-      }
-
-      if (this.cursor >= 0 && this.cursor < this.results.length) {
-        this.goToPage(_.nth(this.results, this.cursor))
-      } else if (this.cursor >= 0) {
-        this.setSearchTerm(_.nth(this.suggestions, this.cursor - this.results.length))
+      if (!this.searchIsLoading && this.cursor >= 0) {
+        if (this.cursor < this.results.length) {
+          this.goToPage(_.nth(this.results, this.cursor))
+        } else if (this.suggestions.length > 0) {
+          this.setSearchTerm(_.nth(this.suggestions, this.cursor - this.results.length))
+        }
       }
     })
   },


### PR DESCRIPTION
When a non-cached query or query with no results is quickly typed, the query is deleted from the search bar.
https://user-images.githubusercontent.com/106627257/171472142-faf5cd7f-3f82-4cc0-9021-56a9c453a7fa.mp4


