### PR TITLE
fix: previous query’s suggestions show up on empty search

### DIFF
--- a/client/components/common/search-results.vue
+++ b/client/components/common/search-results.vue
@@ -35,7 +35,7 @@
           :length='paginationLength'
           circle
         )
-      template(v-if='suggestions && suggestions.length > 0')
+      template(v-if='search && search.length >= 2 && suggestions && suggestions.length > 0')
         v-subheader.white--text.mt-3 {{$t('common:header.searchDidYouMean')}}
         v-list.search-results-suggestions.radius-7(dense, dark)
           template(v-for='(term, idx) of suggestions')


### PR DESCRIPTION
### Issue
After deleting a query, suggestions for that query display when the search is cleared.
![wiki js-suggestions-for-empty-query](https://user-images.githubusercontent.com/106627257/171978710-5d57d16f-9382-48fd-b2b4-9ab52973815d.gif)

### Solution
Display suggestions only when the query is 2+ characters. 
```template(v-if='search && search.length >= 2 && suggestions && suggestions.length > 0')```