### PR TITLE
fix: empty title allowed

### DIFF
--- a/client/components/editor.vue
+++ b/client/components/editor.vue
@@ -24,8 +24,8 @@
           :class='{ "is-icon": $vuetify.breakpoint.mdAndDown }'
           )
           v-icon(color='green', :left='$vuetify.breakpoint.lgAndUp') mdi-check
-          span.grey--text(v-if='$vuetify.breakpoint.lgAndUp && mode !== `create` && !isDirty') {{ $t('editor:save.saved') }}
-          span.white--text(v-else-if='$vuetify.breakpoint.lgAndUp') {{ mode === 'create' ? $t('common:actions.create') : $t('common:actions.save') }}
+          span.white--text(v-if='$vuetify.breakpoint.lgAndUp && isDirty && currentPageTitle && currentPageTitle.length > 0') {{ mode === 'create' ? $t('common:actions.create') : $t('common:actions.save') }}
+          span.grey--text(v-else-if='$vuetify.breakpoint.lgAndUp && mode !== `create`') {{ $t('editor:save.saved') }}
         v-btn.animated.fadeInDown.wait-p1s(
           text
           color='blue'

--- a/server/helpers/error.js
+++ b/server/helpers/error.js
@@ -169,6 +169,10 @@ module.exports = {
     message: 'Page content cannot be empty.',
     code: 6004
   }),
+  PageEmptyTitle: CustomError('PageEmptyTitle', {
+    message: 'Page title cannot be empty.',
+    code: 6015
+  }),
   PageHistoryForbidden: CustomError('PageHistoryForbidden', {
     message: 'You are not authorized to view the history of this page.',
     code: 6012

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -272,6 +272,11 @@ module.exports = class Page extends Model {
       throw new WIKI.Error.PageEmptyContent()
     }
 
+    // - Check for empty page title
+    if (!opts.title || opts.title.length < 1) {
+      throw new WIKI.Error.PageEmptyTitle()
+    }
+
     // -> Format CSS Scripts
     let scriptCss = ''
     if (WIKI.auth.checkAccess(opts.user, ['write:styles'], {
@@ -384,6 +389,11 @@ module.exports = class Page extends Model {
     // -> Check for empty content
     if (!opts.content || _.trim(opts.content).length < 1) {
       throw new WIKI.Error.PageEmptyContent()
+    }
+
+    // - Check for empty page title
+    if (!opts.title || opts.title.length < 1) {
+      throw new WIKI.Error.PageEmptyTitle()
     }
 
     // -> Create version snapshot


### PR DESCRIPTION
## Issues
When creating or editing a page, empty titles can be saved.
## Solution
Created new error code 6015 that will not allow the user to create or save a page with an empty title. Additionally, the save and create button remain stylistically disabled when the title is empty. 
