### PR TITLE
feat: set search results max hits

### DIFF
--- a/server/app/data.yml
+++ b/server/app/data.yml
@@ -96,8 +96,6 @@ defaults:
       maxAge: 600
       methods: 'GET,POST'
       origin: true
-    search:
-      maxHits: 100
     maintainerEmail: security@requarks.io
 localeNamespaces:
   - admin

--- a/server/modules/search/algolia/definition.yml
+++ b/server/modules/search/algolia/definition.yml
@@ -22,3 +22,9 @@ props:
     hint: The name of the index you created under Indices.
     default: wiki
     order: 3
+  maxHits:
+    type: Number
+    title: Max Hits
+    hint: The maximum number of results returned by the search engine.
+    default: 100
+    order: 4

--- a/server/modules/search/algolia/engine.js
+++ b/server/modules/search/algolia/engine.js
@@ -59,7 +59,7 @@ module.exports = {
           description: r.description
         })),
         suggestions: [],
-        totalHits: results.nbHits
+        totalHits: Math.min(results.nbHits, this.config.maxHits)
       }
     } catch (err) {
       WIKI.logger.warn('Search Engine Error:')

--- a/server/modules/search/algolia/engine.js
+++ b/server/modules/search/algolia/engine.js
@@ -48,7 +48,7 @@ module.exports = {
   async query(q, opts) {
     try {
       const results = await this.index.search(q, {
-        hitsPerPage: 50
+        hitsPerPage: this.config.maxHits
       })
       return {
         results: _.map(results.hits, r => ({

--- a/server/modules/search/aws/definition.yml
+++ b/server/modules/search/aws/definition.yml
@@ -85,4 +85,10 @@ props:
       - 'zh-Hans'
       - 'zh-Hant'
     order: 6
+  maxHits:
+    type: Number
+    title: Max Hits
+    hint: The maximum number of results returned by the search engine.
+    default: 100
+    order: 7
 

--- a/server/modules/search/aws/engine.js
+++ b/server/modules/search/aws/engine.js
@@ -156,7 +156,7 @@ module.exports = {
       const results = await this.clientDomain.search({
         query: q,
         partial: true,
-        size: 50
+        size: this.config.maxHits
       }).promise()
       if (results.hits.found < 5) {
         const suggestResults = await this.clientDomain.suggest({

--- a/server/modules/search/aws/engine.js
+++ b/server/modules/search/aws/engine.js
@@ -175,7 +175,7 @@ module.exports = {
           description: _.head(r.fields.description) || ''
         })),
         suggestions: suggestions,
-        totalHits: results.hits.found
+        totalHits: Math.min(results.hits.found, this.config.maxHits)
       }
     } catch (err) {
       WIKI.logger.warn('Search Engine Error:')

--- a/server/modules/search/azure/definition.yml
+++ b/server/modules/search/azure/definition.yml
@@ -22,3 +22,9 @@ props:
     hint: 'Name to use when creating the index. (default: wiki)'
     default: wiki
     order: 3
+  maxHits:
+    type: Number
+    title: Max Hits
+    hint: The maximum number of results returned by the search engine.
+    default: 100
+    order: 4

--- a/server/modules/search/azure/engine.js
+++ b/server/modules/search/azure/engine.js
@@ -128,7 +128,7 @@ module.exports = {
       return {
         results: results.result.value,
         suggestions,
-        totalHits: results.result['@odata.count']
+        totalHits: Math.min(results.result['@odata.count'], this.config.maxHits)
       }
     } catch (err) {
       WIKI.logger.warn('Search Engine Error:')

--- a/server/modules/search/azure/engine.js
+++ b/server/modules/search/azure/engine.js
@@ -98,7 +98,7 @@ module.exports = {
         search: q,
         select: 'id, locale, path, title, description',
         queryType: QueryType.simple,
-        top: 50
+        top: this.config.maxHits
       })
       if (results.result.value.length < 5) {
         // Using plain request, not yet available in library...

--- a/server/modules/search/db/definition.yml
+++ b/server/modules/search/db/definition.yml
@@ -5,4 +5,10 @@ author: requarks.io
 logo: https://static.requarks.io/logo/database.svg
 website: https://www.requarks.io/
 isAvailable: true
-props: {}
+props:
+  maxHits:
+    type: Number
+    title: Max Hits
+    hint: The maximum number of results returned by the search engine.
+    default: 100
+    order: 1

--- a/server/modules/search/db/engine.js
+++ b/server/modules/search/db/engine.js
@@ -46,7 +46,7 @@ module.exports = {
           }
         })
       })
-      .limit(WIKI.config.search.maxHits)
+      .limit(this.config.maxHits)
     return {
       results,
       suggestions: [],

--- a/server/modules/search/elasticsearch/definition.yml
+++ b/server/modules/search/elasticsearch/definition.yml
@@ -44,4 +44,10 @@ props:
     hint: '0 = disabled, Interval in seconds to check for updated list of nodes in cluster. (Default: 0)'
     default: 0
     order: 6
+  maxHits:
+    type: Number
+    title: Max Hits
+    hint: The maximum number of results returned by the search engine.
+    default: 100
+    order: 7
 

--- a/server/modules/search/elasticsearch/engine.js
+++ b/server/modules/search/elasticsearch/engine.js
@@ -110,7 +110,7 @@ module.exports = {
             }
           },
           from: 0,
-          size: 50,
+          size: this.config.maxHits,
           _source: ['title', 'description', 'path', 'locale'],
           suggest: {
             suggestions: {

--- a/server/modules/search/elasticsearch/engine.js
+++ b/server/modules/search/elasticsearch/engine.js
@@ -134,7 +134,7 @@ module.exports = {
           description: r._source.description
         })),
         suggestions: _.reject(_.get(results, 'suggest.suggestions', []).map(s => _.get(s, 'options[0].text', false)), s => !s),
-        totalHits: _.get(results, 'body.hits.total.value', _.get(results, 'body.hits.total', 0))
+        totalHits: _.get(results, 'body.hits.hits.length', _.get(results, 'body.hits.hits', 0))
       }
     } catch (err) {
       WIKI.logger.warn('Search Engine Error: ', _.get(err, 'meta.body.error', err))

--- a/server/modules/search/postgres/definition.yml
+++ b/server/modules/search/postgres/definition.yml
@@ -29,3 +29,9 @@ props:
       - swedish
       - turkish
     order: 1
+  maxHits:
+    type: Number
+    title: Max Hits
+    hint: The maximum number of results returned by the search engine.
+    default: 100
+    order: 2

--- a/server/modules/search/postgres/engine.js
+++ b/server/modules/search/postgres/engine.js
@@ -65,7 +65,7 @@ module.exports = {
         FROM "pagesVector", to_tsquery(?,?) query
         WHERE (query @@ "tokens" OR path ILIKE ?)
       `
-      let qryEnd = `ORDER BY ts_rank(tokens, query) DESC`
+      let qryEnd = `ORDER BY ts_rank(tokens, query) DESC LIMIT ${this.config.maxHits}`
       let qryParams = [this.config.dictLanguage, tsquery(q), `%${q.toLowerCase()}%`]
 
       if (opts.locale) {


### PR DESCRIPTION
## feat: set search results max hits
Added a new field for users to set the maximum number of results returned from the search engine. 
![image(7)](https://user-images.githubusercontent.com/106627257/173258155-2d936af5-1505-402e-bb9e-8218c205772c.png)

## fix: total hits displayed instead of max hits
### Problem
Currently, if the total hits are larger than the max hits set in algolia, aws, azure, or elasticsearch search engines, when a user attempts to view pages past the max hits, the empty results page is displayed. For example, if the max hit is set to 20, the pages 1-2 will be viewable. However, if the 3rd+ page is clicked on, the empty results page is displayed. 
![wiki js-total-hits-display-instead-of-max-hits](https://user-images.githubusercontent.com/106627257/173258163-2db5e84e-2d91-46f2-ac6b-e965a726a620.gif)

### Solution
Display min(results returned size, max hits) instead of total hits. 