### PR TITLE
Fix detection of puppeteer

### DIFF
--- a/server/modules/extensions/puppeteer/ext.js
+++ b/server/modules/extensions/puppeteer/ext.js
@@ -1,4 +1,3 @@
-const cmdExists = require('command-exists')
 const os = require('os')
 
 module.exports = {
@@ -11,7 +10,7 @@ module.exports = {
   isInstalled: false,
   async check () {
     try {
-      await cmdExists('pandoc')
+      require.resolve('puppeteer')
       this.isInstalled = true
     } catch (err) {
       this.isInstalled = false


### PR DESCRIPTION
Previously, there seemed to be a copy/paste error: The `isInstalled` check for puppeteer actually checked if the pandoc executable is installed.

Now it checks for the availability of the puppeteer npm module