### PR TITLE
feat: search title and redirect when page not found

### DIFF
--- a/client/client-app.js
+++ b/client/client-app.js
@@ -156,6 +156,7 @@ Vue.component('loader', () => import(/* webpackPrefetch: true, webpackChunkName:
 Vue.component('login', () => import(/* webpackPrefetch: true, webpackChunkName: "login" */ './components/login.vue'))
 Vue.component('nav-header', () => import(/* webpackMode: "eager" */ './components/common/nav-header.vue'))
 Vue.component('new-page', () => import(/* webpackChunkName: "new-page" */ './components/new-page.vue'))
+Vue.component('disambiguation', () => import(/* webpackChunkName: "disambiguation" */ './components/disambiguation.vue'))
 Vue.component('notify', () => import(/* webpackMode: "eager" */ './components/common/notify.vue'))
 Vue.component('not-found', () => import(/* webpackChunkName: "not-found" */ './components/not-found.vue'))
 Vue.component('page-selector', () => import(/* webpackPrefetch: true, webpackChunkName: "ui-extra" */ './components/common/page-selector.vue'))

--- a/client/components/disambiguation.vue
+++ b/client/components/disambiguation.vue
@@ -1,0 +1,51 @@
+<template lang='pug'>
+  v-app
+    div(class='disambiguation')
+      h1 {{ $t('disambiguation.title') }}
+      p {{ $t('disambiguation.subtitle') }}
+      span(v-for='(page,index) in pagesArr' :key='index')
+        a(:href='page.path') {{ page.path }}
+      v-btn.mt-5(color='purple lighten-3', href='javascript:window.history.go(-1);', outlined)
+        v-icon(left) mdi-arrow-left
+        span {{ $t('disambiguation.goback') }}
+</template>
+
+<style scoped>
+.disambiguation {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  min-height: 100%;
+  background: url('../static/svg/motif-overlay.svg');
+  background-size: 100%;
+  color: white;
+}
+span{
+  margin: 0.5rem 0;
+}
+a {
+  text-decoration: none;
+}
+</style>
+
+<script>
+
+export default {
+  props: {
+    pages: {
+      type: String,
+      default: ""
+    },
+  },
+  computed:{
+    pagesArr(){
+      return JSON.parse(this.pages)
+    }
+  },
+  data() {
+    return { }
+  }
+}
+
+</script>

--- a/server/controllers/common.js
+++ b/server/controllers/common.js
@@ -555,6 +555,14 @@ router.get('/*', async (req, res, next) => {
         _.set(res.locals, 'pageMeta.title', 'Welcome')
         res.render('welcome', { locale: pageArgs.locale })
       } else {
+        const pages = await WIKI.models.pages.getPageIDWithTitle(pageArgs.path)
+        if (pages.length === 1) {
+          return res.redirect(`/${pageArgs.locale}/${pages[0].path}`)
+        } else if (pages.length > 1) {
+          _.set(res.locals, 'pageMeta.title', 'Disambiguate')
+          res.status(404).render('disambiguate', { pages })
+          return
+        }
         _.set(res.locals, 'pageMeta.title', 'Page Not Found')
         if (effectivePermissions.pages.write) {
           res.status(404).render('new', { path: pageArgs.path, locale: pageArgs.locale })

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -966,6 +966,16 @@ module.exports = class Page extends Model {
     }
     return page
   }
+  /**
+   * 
+   * @param {String} title Page title
+   * @returns {Promise} Promise of the Page id and path
+   */
+  static async getPageIDWithTitle(title) {
+    return WIKI.models.pages.query()
+      .column(['pages.id', 'pages.path'])
+      .where({'pages.title': title})
+  }
 
   /**
    * Fetch an Existing Page from the Database

--- a/server/views/disambiguate.pug
+++ b/server/views/disambiguate.pug
@@ -1,0 +1,5 @@
+extends master.pug
+
+block body
+  #root.is-fullscreen
+    disambiguation(pages=pages)


### PR DESCRIPTION
if can not find the page with the path, use the path as title, search and redirect to result page.

if multiple pages hava the same title, a disambiguation page will be displayed.

To simplify the path, like en/science/computer/programming language/javascript => en/javascript