### PR TITLE
feat: allow self-signed ssl

### DIFF
--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -41,9 +41,11 @@ spec:
           env:
             - name: DB_TYPE
               value: postgres
-            {{- if .Values.externalPostgresql.databaseURL }}
+            {{- if (.Values.externalPostgresql).databaseURL }}
             - name: DATABASE_URL
               value: {{ .Values.externalPostgresql.databaseURL }}
+            - name: NODE_TLS_REJECT_UNAUTHORIZED
+              value: {{ default "1" .Values.externalPostgresql.NODE_TLS_REJECT_UNAUTHORIZED | quote }}
             {{- else }}
             - name: DB_HOST
               value: {{ template "wiki.postgresql.host" . }}
@@ -81,6 +83,8 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.startupProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -32,6 +32,16 @@ readinessProbe:
     path: /healthz
     port: http
 
+startupProbe:
+  initialDelaySeconds: 15
+  periodSeconds: 5
+  timeoutSeconds: 5
+  successThreshold: 1
+  failureThreshold: 60
+  httpGet:
+    path: /healthz
+    port: http
+
 podSecurityContext: {}
   # fsGroup: 2000
 
@@ -104,7 +114,10 @@ sideload:
 
 ## This will override the postgresql chart values
 # externalPostgresql:
-#   databaseURL: postgresql://postgres:postgres@postgres:5432/wiki?sslmode=require
+#   # note: ?sslmode=require => ?ssl=true
+#   databaseURL: postgresql://postgres:postgres@postgres:5432/wiki?ssl=true
+#   # For self signed CAs, like DigitalOcean
+#   NODE_TLS_REJECT_UNAUTHORIZED: "0"
 
 ## Configuration values for the postgresql dependency.
 ## ref: https://github.com/kubernetes/charts/blob/master/stable/postgresql/README.md


### PR DESCRIPTION
I could not seem to get around the self signed easily. this works perhaps 2 would be better but I could not get it to work even when passed as a string without the head/footer

https://gist.github.com/zmts/f3306945e90914c4dedda5e0eaf1a279#solution-2

Added
feat: startup probe

at any rate this will work with DO connection string with the change of sslmode=require to ssl=true. could handle but likely a note is sufficient or maybe os obvious. 