### PR TITLE
feat: add elasticsearch ssl options

### DIFF
--- a/server/modules/search/elasticsearch/definition.yml
+++ b/server/modules/search/elasticsearch/definition.yml
@@ -20,28 +20,37 @@ props:
     title: Host(s)
     hint: Comma-separated list of Elasticsearch hosts to connect to, including the port, username and password if necessary. (e.g. http://localhost:9200, https://user:pass@es1.example.com:9200)
     order: 2
+  verifyTLSCertificate:
+    title: Verify TLS Certificate
+    type: Boolean
+    default: true
+    order: 3
+  tlsCertPath:
+    title: TLS Certificate Path
+    type: String
+    hint: Absolute path to the TLS certificate on the server.
+    order: 4
   indexName:
     type: String
     title: Index Name
     hint: The index name to use during creation
     default: wiki
-    order: 3
+    order: 5
   analyzer:
     type: String
     title: Analyzer
     hint: 'The token analyzer in elasticsearch'
     default: simple
-    order: 4
+    order: 6
   sniffOnStart:
     type: Boolean
     title: Sniff on start
     hint: 'Should Wiki.js attempt to detect the rest of the cluster on first connect? (Default: off)'
     default: false
-    order: 5
+    order: 7
   sniffInterval:
     type: Number
     title: Sniff Interval
     hint: '0 = disabled, Interval in seconds to check for updated list of nodes in cluster. (Default: 0)'
     default: 0
-    order: 6
-
+    order: 8

--- a/server/modules/search/elasticsearch/engine.js
+++ b/server/modules/search/elasticsearch/engine.js
@@ -358,7 +358,7 @@ module.exports = {
 function getTlsOptions(conf) {
   if (!conf.tlsCertPath) {
     return {
-      rejectUnauthorized: conf.verifyTLSCertificate,
+      rejectUnauthorized: conf.verifyTLSCertificate
     }
   }
 

--- a/server/modules/search/elasticsearch/engine.js
+++ b/server/modules/search/elasticsearch/engine.js
@@ -1,6 +1,7 @@
 const _ = require('lodash')
 const stream = require('stream')
 const Promise = require('bluebird')
+const fs = require('fs')
 const pipeline = Promise.promisify(stream.pipeline)
 
 /* global WIKI */
@@ -24,6 +25,7 @@ module.exports = {
           nodes: this.config.hosts.split(',').map(_.trim),
           sniffOnStart: this.config.sniffOnStart,
           sniffInterval: (this.config.sniffInterval > 0) ? this.config.sniffInterval : false,
+          ssl: getTlsOptions(this.config),
           name: 'wiki-js'
         })
         break
@@ -33,6 +35,7 @@ module.exports = {
           nodes: this.config.hosts.split(',').map(_.trim),
           sniffOnStart: this.config.sniffOnStart,
           sniffInterval: (this.config.sniffInterval > 0) ? this.config.sniffInterval : false,
+          ssl: getTlsOptions(this.config),
           name: 'wiki-js'
         })
         break
@@ -349,5 +352,23 @@ module.exports = {
       })
     )
     WIKI.logger.info(`(SEARCH/ELASTICSEARCH) Index rebuilt successfully.`)
+  }
+}
+
+function getTlsOptions(conf) {
+  if (!conf.tlsCertPath) {
+    return {
+      rejectUnauthorized: conf.verifyTLSCertificate,
+    }
+  }
+
+  const caList = []
+  if (conf.verifyTLSCertificate) {
+    caList.push(fs.readFileSync(conf.tlsCertPath))
+  }
+
+  return {
+    rejectUnauthorized: conf.verifyTLSCertificate,
+    ca: caList
   }
 }


### PR DESCRIPTION
I added ssl options for elasticsearch. This allows the use of elasticsearch with self signed certificates.

![image](https://user-images.githubusercontent.com/6772159/180383829-1739cecd-aac1-4e6e-948d-f02f4fd355c3.png)
