### PR TITLE
fix: Keycloak Authentication logout error with keycloak 18 or newer

### DIFF
--- a/server/modules/authentication/keycloak/authentication.js
+++ b/server/modules/authentication/keycloak/authentication.js
@@ -47,7 +47,8 @@ module.exports = {
     if (!conf.logoutUpstream) {
       return '/'
     } else if (conf.logoutURL && conf.logoutURL.length > 5) {
-      return `${conf.logoutURL}?redirect_uri=${encodeURIComponent(WIKI.config.host)}`
+      // TODO: Implement new logout mechanism from keycloak 18: https://www.keycloak.org/docs/latest/upgrading/index.html#openid-connect-logout
+      return `${conf.logoutURL}`
     } else {
       WIKI.logger.warn('Keycloak logout URL is not configured!')
       return '/'


### PR DESCRIPTION
As described in https://github.com/requarks/wiki/discussions/5213 trying to log-out when using the keycloak authentication strategy and `Logout from Keycloak on Logout` enabled you will currently receive an `Invalid parameter: redirect_uri` error in keycloak, making logout essentially useless.
As described in the discussion linked above and in https://www.keycloak.org/docs/latest/upgrading/index.html#openid-connect-logout the ideal solution would be to use an `id_token_hint` together with  `post_logout_redirect_uri` in the logout request to achieve a seamless logout.
I was however not sure how to get that ID Token in the logout function, so I went with the second option to restore logout functionality.
This temporarly adds an additional step for the user having to seperately click on "Logout" in keycloak and doesn't redirect the user back to the wiki, which isn't ideal, but IMO better than having no logout at all.