### PR TITLE
Fix page cursor and pagination

### DIFF
--- a/client/components/common/search-results.vue
+++ b/client/components/common/search-results.vue
@@ -105,6 +105,9 @@ export default {
       } else {
         this.searchIsLoading = true
       }
+    },
+    results() {
+      this.cursor = 0
     }
   },
   mounted() {

--- a/client/components/common/search-results.vue
+++ b/client/components/common/search-results.vue
@@ -153,6 +153,9 @@ export default {
       skip() {
         return !this.search || this.search.length < 2
       },
+      result() {
+        this.pagination = 1
+      },
       update: (data) => _.get(data, 'pages.search', {}),
       watchLoading (isLoading) {
         this.searchIsLoading = isLoading


### PR DESCRIPTION
#### Note
I originally opened the same request on a now deleted account, and will submit pull requests from this account instead - thank you for your understanding. 

### Page Cursor

**fix: page cursor position stays the same between page selection**
Given a query with multiple result pages, if the cursor is moved to a result entry, then the user selects a different page, the cursor remains on the previous position.
![wiki js-fix-page-cursor](https://user-images.githubusercontent.com/106627257/171290472-c00c893b-da39-47ab-915e-f3207273a68c.gif)

### Pagination

**fix: search results not displaying on first page**
Given a query with multiple result pages, if a certain page is selected, then another query (with the same or more result pages as the previous entry) is searched, the results will display on the previously selected page. 
![wiki js-pagination](https://user-images.githubusercontent.com/106627257/171290695-3690c1a7-b6e1-4d4e-8d5e-91bc0533ccd0.gif)
