### PR TITLE
Add logout for auth0

### DIFF
--- a/server/modules/authentication/auth0/authentication.js
+++ b/server/modules/authentication/auth0/authentication.js
@@ -27,5 +27,8 @@ module.exports = {
         }
       }
       ))
+  },
+  logout (conf) {
+    return `https://${conf.domain}/v2/logout?${new URLSearchParams({ client_id: conf.clientId, returnTo: WIKI.config.host }).toString()}`
   }
 }


### PR DESCRIPTION
Currently the Auth0 authentication module doesn't log users out of auth0, so if they choose Auth0 again, they'll already be logged in.

This adds a logout func to the Auth0 authentication module so that users are fully logged out on logout.