### PR TITLE
Integrate Uffizzi PR Environments

### DIFF
--- a/.github/workflows/uffizzi-preview-delete.yml
+++ b/.github/workflows/uffizzi-preview-delete.yml
@@ -1,0 +1,25 @@
+name: Build Images and Handle Uffizzi Previews.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-uffizzi-preview:
+    name: Use Remote Workflow to Delete an Existing Preview
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@v2.1.0
+    if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+    with:
+      compose-file-cache-key: ''
+      compose-file-cache-path: docker-compose.rendered.yml
+      username: vibhav.bobade+wikijs@uffizzi.com
+      server: https://app.uffizzi.com
+      project: wikijs-gyyp
+    secrets:
+      password: ${{ secrets.UFFIZZI_PASSWORD }}
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/uffizzi-preview-deploy.yml
+++ b/.github/workflows/uffizzi-preview-deploy.yml
@@ -1,0 +1,91 @@
+name: Build Images and Handle Uffizzi Previews.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened,reopened,synchronize]
+
+jobs:
+  build-wiki:
+    name: Build and Push `wiki`
+    runs-on: ubuntu-latest
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Set Build Variables
+        run: |
+          if [[ "$GITHUB_REF" =~ ^refs/tags/v* ]]; then
+            echo "Using TAG mode: $GITHUB_REF_NAME"
+            echo "REL_VERSION=$GITHUB_REF_NAME" >> $GITHUB_ENV
+            echo "REL_VERSION_STRICT=${GITHUB_REF_NAME#?}" >> $GITHUB_ENV
+          else
+            echo "Using BRANCH mode: v$BASE_DEV_VERSION-dev.$GITHUB_RUN_NUMBER"
+            echo "REL_VERSION=v$BASE_DEV_VERSION-dev.$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
+            echo "REL_VERSION_STRICT=$BASE_DEV_VERSION-dev.$GITHUB_RUN_NUMBER" >> $GITHUB_ENV
+          fi
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/requarks-wiki-${{ env.REL_VERSION_STRICT }}
+      - name: Build and Push Image to GHCR
+        uses: docker/build-push-action@v2.9.0
+        with:
+          context: .
+          file: dev/build/Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+
+  render-compose-file:
+    name: Render Docker Compose File
+    runs-on: ubuntu-latest
+    needs: 
+      - build-wiki
+    outputs:
+      compose-file-cache-key: ${{ steps.hash.outputs.hash }}
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+      - name: Render Compose File
+        run: |
+          WIKI_IMAGE=$(echo ${{ needs.build-wiki.outputs.tags }})
+          export WIKI_IMAGE
+          # Render simple template from environment variables.
+          envsubst < dev/uffizzi/docker-compose.template.yml > docker-compose.rendered.yml
+          cat docker-compose.rendered.yml
+      - name: Hash Rendered Compose File
+        id: hash
+        run: echo "::set-output name=hash::$(md5sum docker-compose.rendered.yml | awk '{ print $1 }')"
+      - name: Cache Rendered Compose File
+        uses: actions/cache@v3
+        with:
+          path: docker-compose.rendered.yml
+          key: ${{ steps.hash.outputs.hash }}
+
+  deploy-uffizzi-preview:
+    name: Use Remote Workflow to Preview on Uffizzi
+    needs: render-compose-file
+    uses: UffizziCloud/preview-action/.github/workflows/reusable.yaml@add_credentials
+    if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
+    with:
+      compose-file-cache-key: ${{ needs.render-compose-file.outputs.compose-file-cache-key }}
+      compose-file-cache-path: docker-compose.rendered.yml
+      username: vibhav.bobade+wikijs@uffizzi.com
+      server: https://app.uffizzi.com
+      project: wikijs-gyyp
+    secrets:
+      password: ${{ secrets.UFFIZZI_PASSWORD }}
+    permissions:
+      contents: read
+      pull-requests: write

--- a/dev/containers/Dockerfile
+++ b/dev/containers/Dockerfile
@@ -1,18 +1,54 @@
-# -- DEV DOCKERFILE --
-# -- DO NOT USE IN PRODUCTION! --
+# ====================
+# --- Build Assets ---
+# ====================
+FROM node:16-alpine AS assets
 
-FROM node:14
-LABEL maintainer "requarks.io"
-
-RUN apt-get update && \
-    apt-get install -y bash curl git python make g++ nano openssh-server gnupg && \
-    mkdir -p /wiki
+RUN apk add yarn g++ make cmake python3 --no-cache
 
 WORKDIR /wiki
 
-ENV dockerdev 1
-ENV DEVDB postgres
+COPY ./client ./client
+COPY ./dev ./dev
+COPY ./package.json ./package.json
+COPY ./.babelrc ./.babelrc
+COPY ./.eslintignore ./.eslintignore
+COPY ./.eslintrc.yml ./.eslintrc.yml
+
+RUN yarn cache clean
+RUN yarn --frozen-lockfile --non-interactive
+RUN yarn build
+RUN rm -rf /wiki/node_modules
+RUN yarn --production --frozen-lockfile --non-interactive
+
+# ===============
+# --- Release ---
+# ===============
+FROM node:16-alpine
+LABEL maintainer="requarks.io"
+
+RUN apk add bash curl git openssh gnupg sqlite --no-cache && \
+    mkdir -p /wiki && \
+    mkdir -p /logs && \
+    mkdir -p /wiki/data/content && \
+    chown -R node:node /wiki /logs
+
+WORKDIR /wiki
+
+COPY --chown=node:node --from=assets /wiki/assets ./assets
+COPY --chown=node:node --from=assets /wiki/node_modules ./node_modules
+COPY --chown=node:node ./server ./server
+COPY --chown=node:node --from=assets /wiki/server/views ./server/views
+COPY --chown=node:node ./dev/build/config.yml ./config.yml
+COPY --chown=node:node ./package.json ./package.json
+COPY --chown=node:node ./LICENSE ./LICENSE
+
+USER node
+
+VOLUME ["/wiki/data/content"]
 
 EXPOSE 3000
+EXPOSE 3443
 
-CMD ["tail", "-f", "/dev/null"]
+# HEALTHCHECK --interval=30s --timeout=30s --start-period=30s --retries=3 CMD curl -f http://localhost:3000/healthz
+
+CMD ["node", "server"]

--- a/dev/uffizzi/docker-compose.template.yml
+++ b/dev/uffizzi/docker-compose.template.yml
@@ -6,9 +6,9 @@ version: "3"
 x-uffizzi:
   ingress:
     service: wiki
-    port: 80
+    port: 3000
 
-services: 
+services:
   db:
     image: postgres:11-alpine
     environment:
@@ -16,26 +16,27 @@ services:
       POSTGRES_PASSWORD: wikijsrocks
       POSTGRES_USER: wikijs
     restart: unless-stopped
-    volumes:
-      - db-data:/var/lib/postgresql/data
+    deploy:
+      resources:
+        limits:
+          memory: 500M
 
   wiki:
-    build:
-      context: https://github.com/waveywaves/requarks-wiki
-      dockerfile: Dockerfile
+    image: "${WIKI_IMAGE}"
     depends_on:
       - db
     environment:
       DB_TYPE: postgres
-      DB_HOST: db
+      DB_HOST: localhost
       DB_PORT: 5432
       DB_USER: wikijs
       DB_PASS: wikijsrocks
       DB_NAME: wiki
     restart: unless-stopped
     ports:
-      - "80:3000"
-
-volumes:
-  db-data:
+      - "3000"
+    deploy:
+      resources:
+        limits:
+          memory: 500M
 


### PR DESCRIPTION
Add support to spin up environments for every PR. This will help in debugging WikiJS alongside a Postgres instance on the PR easily without having to run the code locally. 
- Add github action to build image on every PR
- Use the built image to create a PR Environment for testing Wiki.js
- Initial support for Postgres.

