### PR TITLE
feat: [nav] tag to render a list of child pages

### DIFF
--- a/client/themes/default/components/page.vue
+++ b/client/themes/default/components/page.vue
@@ -316,6 +316,7 @@
 </template>
 
 <script>
+/* global graphQL */
 import { StatusIndicator } from 'vue-status-indicator'
 import Tabset from './tabset.vue'
 import NavSidebar from './nav-sidebar.vue'
@@ -325,6 +326,7 @@ import { get, sync } from 'vuex-pathify'
 import _ from 'lodash'
 import ClipboardJS from 'clipboard'
 import Vue from 'vue'
+import gql from 'graphql-tag'
 
 Vue.component('Tabset', Tabset)
 
@@ -583,8 +585,96 @@ export default {
         }
       })
     })
+
+    if (this.containsNavElement()) {
+      const currentPagePath = this.$store.get('page/path')
+      this.getPageIdFromPath(currentPagePath).then((result) => {
+        if (result !== null) {
+          const childPages = this.getChildPages(result.id)
+          this.renderPageList(childPages)
+        }
+      })
+    }
   },
   methods: {
+    containsNavElement() {
+      const contents = document.getElementsByClassName('contents')
+      contents[0].firstChild.childNodes.forEach((child) => {
+        if (child.nodeType === 3 && child.nodeValue && child.nodeValue.indexOf('[nav]') !== -1) {
+          return true
+        } else if (child.nodeType === 1 && child.innerHTML === '[nav]') {
+          return true
+        }
+      })
+      return false
+    },
+    getPageIdFromPath(currentPagePath) {
+      const query = gql`
+        query ($path: String, $locale: String!) {
+          pages {
+            tree(path: $path, mode: ALL, locale: $locale) {
+              id
+              pageId
+              path
+            }
+          }
+        }`
+      return graphQL.query({
+        query: query,
+        variables: {
+          path: currentPagePath,
+          locale: 'en'
+        }
+      }).then(resp => {
+        const pageIds = resp.data.pages.tree.filter(item => item.path === currentPagePath)
+        if (pageIds.length > 0) {
+          return pageIds[0]
+        }
+        return null
+      }).catch(err => {
+        console.error(err)
+      })
+    },
+    getChildPages(currentPageID) {
+      const variables = {
+        parent: currentPageID,
+        locale: 'en'
+      }
+      const query = gql`
+        query Page($locale: String!, $parent: Int!) {
+          pages {
+            tree(mode: ALL, locale: $locale, parent: $parent) {
+              title
+              path
+              locale
+            }
+          }
+        }`
+      return graphQL.query({
+        query: query,
+        variables: variables
+      }).then(resp => {
+        const childPages = resp.data.pages.tree.filter(item => item.id !== currentPageID.toString())
+        return childPages
+      }).catch(err => {
+        console.error(err)
+      })
+    },
+    renderPageList (childPages) {
+      childPages.then((result) => {
+        const pageListMarkup = `<ul>${result.map(child => {
+          return `<li><a href="/${child.path}">${child.title}</a></li>`
+        }).join('')}</ul>`
+        const contents = document.getElementsByClassName('contents')
+        contents[0].firstChild.childNodes.forEach((child) => {
+          if (child.nodeType === 3 && child.nodeValue && child.nodeValue.indexOf('[nav]') !== -1) {
+            child.innerHTML = child.innerHTML.replace('[nav]', pageListMarkup)
+          } else if (child.nodeType === 1 && child.innerHTML === '[nav]') {
+            child.innerHTML = child.innerHTML.replace('[nav]', pageListMarkup)
+          }
+        })
+      })
+    },
     goHome () {
       window.location.assign('/')
     },


### PR DESCRIPTION
This PR introduces a `[nav]` tag that can be added when editing content pages in any of the editors (raw html, visual, markdown).

When the page is rendered, the `[nav]` tag is replaced with a dynamic list of all the child pages of the current page.

![Screenshot 2022-09-07 at 10 31 36](https://user-images.githubusercontent.com/30590452/188844610-995ff489-8793-4d52-ae56-9b892bc0d486.png)
![Screenshot 2022-09-07 at 10 31 59](https://user-images.githubusercontent.com/30590452/188844613-c4dcb1f9-3dd2-45c8-939d-8399b24fe68c.png)

This is a feature that's been on my wish list for the wiki and has been requested before by other members of the community, https://js.wiki/feedback/p/sub-pages-list. We love the wiki at my company, so a couple of us had a look at what we could do to implement this.

The feature works by analysing the page HTML contents, to check if an element or text node contains the `[nav]` string.

If the strings exists, we start by finding the page id using the path of the current page. We have to do a string match on the path of the pages from the results to get the id. Then, using that page id, we run another query to get all the child pages of the parent page matching that id.

Unfortunately this does require two graphql queries, but these are the same queries that the sidenav runs when clicking through the folders, so I'm guessing this is the only/most efficient way of doing it.

From there, we replace the `[nav]` tag with the page list HTML.

I'd love some feedback on the PR. The functionality is very basic for now. In the future I'd like to add things like optionally rendering children of children, or rendering a page list of a different parent page by specifying the path in the tag, but for version 1 I'd like to keep it simple, what do you think?

The `[nav]` tag works a treat, but there is a brief delay after loading the page while the graphql queries run, so you might see `[nav]` for a split second before the page list is rendered. Could this code be moved somewhere else, other than `page.vue` to avoid this?

Is `page.vue` in the themes folder the best place for this, or should it be moved somewhere else?

Also currently I have the locale hardcoded to `en` so I need to find out how to get it programatically instead.