### PR TITLE
Enhance error Logging

### DIFF
--- a/server/core/logger.js
+++ b/server/core/logger.js
@@ -1,26 +1,61 @@
 // const _ = require('lodash')
 const winston = require('winston')
 
+
 /* global WIKI */
+
+let WikiErrorFormat = winston.format((info)=>{
+	
+	var errorObject = null;
+	
+	if(info instanceof Error){
+		errorObject = info;
+	}
+	else if(info.message instanceof Error){
+		errorObject = info.message;
+	}
+	
+	info._wiki_error = errorObject;
+	
+	return info;
+})
+
+
+let WikiLoggerPrintf = (info) =>{
+		var msg = info.message;
+		
+		if(info._wiki_error){
+			msg = info._wiki_error.stack;
+		}
+		
+		
+		
+		return `${info.timestamp} [${info.label}] ${info.level}: ${msg}`;
+		
+	}
+
+
 
 module.exports = {
   loggers: {},
   init(uid) {
     const loggerFormats = [
+	  WikiErrorFormat(),
       winston.format.label({ label: uid }),
       winston.format.timestamp()
+     ,winston.format.errors({stack: true })
     ]
 
     if (WIKI.config.logFormat === 'json') {
       loggerFormats.push(winston.format.json())
     } else {
       loggerFormats.push(winston.format.colorize())
-      loggerFormats.push(winston.format.printf(info => `${info.timestamp} [${info.label}] ${info.level}: ${info.message}`))
+	  loggerFormats.push(winston.format.printf(WikiLoggerPrintf))
     }
 
     const logger = winston.createLogger({
-      level: WIKI.config.logLevel,
-      format: winston.format.combine(...loggerFormats)
+      level: WIKI.config.logLevel
+      ,format: winston.format.combine(...loggerFormats)
     })
 
     // Init Console (default)

--- a/server/core/logger.js
+++ b/server/core/logger.js
@@ -43,7 +43,6 @@ module.exports = {
 	  WikiErrorFormat(),
       winston.format.label({ label: uid }),
       winston.format.timestamp()
-     ,winston.format.errors({stack: true })
     ]
 
     if (WIKI.config.logFormat === 'json') {


### PR DESCRIPTION
This will enhance the logging of error messages in catch blocks (the javascript Error object).

Due to a problem on wiston, when logging an error object, the winston just prints the messages, and all important details (like error line, etc,) is hidden. Details: https://github.com/winstonjs/winston/issues/1338

For example, if I'm developing a module or something fails with an Error, this is what is printed in the wiki.js log:


![image](https://user-images.githubusercontent.com/16887793/190544941-3949f9d2-c59c-4c38-810e-5fc1e0c580f9.png)




After this fix, the error is printed with more info:

![image](https://user-images.githubusercontent.com/16887793/190545033-5f13ed37-6e01-478a-b958-5cc6379d67d4.png)


