### PR TITLE
ci: replace hosted `semver` with an action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -285,14 +285,16 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Parse REL_VERSION_STRICT
+      uses: madhead/semver-utils@latest
+      id: version
+      with:
+        version: ${{ env.REL_VERSION_STRICT }}
+
     - name: Create and Push Manifests
       run: |
-        echo "Fetching semver tool..."
-        curl -LJO https://static.requarks.io/semver
-        chmod +x semver
-
-        MAJOR=`./semver get major $REL_VERSION_STRICT`
-        MINOR=`./semver get minor $REL_VERSION_STRICT`
+        MAJOR=${{ steps.version.outputs.major }}
+        MINOR=${{ steps.version.outputs.minor }}
         MAJORMINOR="$MAJOR.$MINOR"
 
         echo "Using major $MAJOR and minor $MINOR..."


### PR DESCRIPTION
I've noticed, that you are using a self-hosted and publicly accessible `semver` bash script ([static.requarks.io/semver](https://static.requarks.io/semver), probably a slightly outdated fork of [fsaintjacques/semver-tool](https://github.com/fsaintjacques/semver-tool)) to parse semantic versions.

I propose to use [my reusable GitHub Action](https://github.com/marketplace/actions/semver-utils) to accomplish the same task. Using the action has, from my point of view, some benefits:

✔️ No need to host a script anymore
✔️ One less dependency to worry about: the action could use `@latest` tag, while a hosted script, I guess, requires some sort of a redeployment
✔️ The build would become independent of the site. It includes both possible network issues (like DNS) and site name (who knows if you want a rebranding one day?)
✔️ Using an action just looks like a more straightforward way of doing that.

If you would like to ensure it works the same way as before, I've tested it in my fork:
- A successful run is [here](https://github.com/madhead/requarks-wiki/actions/runs/3094290697/jobs/5007509577#step:4:12)
- The workflow I used for the check is [here](https://github.com/madhead/requarks-wiki/actions/runs/3094290697/workflow)

_Thanks you!_