### PR TITLE
add loadBalancerIP param in helmchart

### DIFF
--- a/dev/helm/templates/service.yaml
+++ b/dev/helm/templates/service.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
 spec:
   type: {{.Values.service.type}}
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  loadBalancerIP: {{ default "" .Values.service.loadBalancerIP }}
+  {{- end }}
   ports:
     - port: {{ default "80" .Values.service.port}}
       targetPort: http

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -61,6 +61,7 @@ service:
   # type: LoadBalancer
   # httpsPort: 443
   # annotations: {}
+  # loadBalancerIP: 172.16.0.1
 
 ingress:
   enabled: true


### PR DESCRIPTION
Hello!

When service.type is LoadBarancer, Made it possible to specify the IPAddress.
Please check it. 😃