### PR TITLE
OIDC patch

### DIFF
--- a/server/modules/authentication/oidc/authentication.js
+++ b/server/modules/authentication/oidc/authentication.js
@@ -38,7 +38,7 @@ module.exports = {
                 await user.$relatedQuery('groups').relate(groupId)
               }
               for (const groupId of _.difference(currentGroups, expectedGroups)) {
-                await user.$relatedQuery('groups').unrelate(groupId)
+                await user.$relatedQuery('groups').unrelate().where('groups.id', '=', groupId)
               }
             }
           }

--- a/server/modules/authentication/oidc/authentication.js
+++ b/server/modules/authentication/oidc/authentication.js
@@ -32,7 +32,7 @@ module.exports = {
           if (conf.mapGroups) {
             const groups = _.get(profile, '_json.' + conf.groupsClaim)
             if (groups && _.isArray(groups)) {
-              const currentGroups = (await user.$relatedQuery('groups').select('groups.id')).groups.map(g => g.id)
+              const currentGroups = (await user.$relatedQuery('groups').select('groups.id')).map(g => g.id)
               const expectedGroups = Object.values(WIKI.auth.groups).filter(g => groups.includes(g.name)).map(g => g.id)
               for (const groupId of _.difference(expectedGroups, currentGroups)) {
                 await user.$relatedQuery('groups').relate(groupId)

--- a/server/modules/authentication/oidc/definition.yml
+++ b/server/modules/authentication/oidc/definition.yml
@@ -55,15 +55,21 @@ props:
     hint: Map groups matching names from the groups claim value
     default: false
     order: 8
+  createGroups:
+    type: Boolean
+    title: Create Mapped Groups
+    hint: Create new groups from idp if they don't exist
+    default: false
+    order: 9
   groupsClaim:
     type: String
     title: Groups Claim
     hint: Field containing the group names
     default: groups
     maxWidth: 500
-    order: 9
+    order: 10
   logoutURL:
     type: String
     title: Logout URL
     hint: (optional) Logout URL on the OAuth2 provider where the user will be redirected to complete the logout process.
-    order: 10
+    order: 11


### PR DESCRIPTION
Fixed two errors on a new oidc group mapping feature:
1. When getting a list current groups of user there was an error, fixed it
<img width="788" alt="Снимок экрана 2022-10-05 в 10 35 08" src="https://user-images.githubusercontent.com/40176967/194005764-01915ee2-1c2a-4922-ae50-bc1523ed32fc.png">
2. Unrelation query caused an error, fixed it
<img width="987" alt="Снимок экрана 2022-10-05 в 10 34 07" src="https://user-images.githubusercontent.com/40176967/194005601-ab37ccd9-b713-41c2-ae01-13a529d6a946.png">

Also, added a flag to enable automatic creation of new groups from idp if they don't exist

Tested locally, looks like it works
