### PR TITLE
add authentication module to use a JWT token

### DIFF
--- a/server/modules/authentication/jwt/authentication.js
+++ b/server/modules/authentication/jwt/authentication.js
@@ -1,0 +1,41 @@
+/* global WIKI */
+
+// ------------------------------------
+// JWT Token
+// ------------------------------------
+
+const JwtStrategy = require('passport-jwt').Strategy
+const ExtractJwt = require('passport-jwt').ExtractJwt
+
+module.exports = {
+  init (passport, conf) {
+    passport.use(conf.key,
+      new JwtStrategy({
+        algorithms: ['HS256'],
+        secretOrKey: conf.jwtSecret,
+        jwtFromRequest: ExtractJwt.fromUrlQueryParameter('auth_token')
+      }, async (jwtPayload, cb) => {
+        try {
+          if (jwtPayload.iat == null) {
+            throw new WIKI.Error.AuthLoginFailed()
+          }
+          const millisElapsed = Date.now() - jwtPayload.iat * 1000
+          const minutesElapsed = Math.floor(millisElapsed / 1000 / 60)
+          if (minutesElapsed > 60) {
+            throw new WIKI.Error.AuthLoginFailed()
+          }
+          const user = await WIKI.models.users.processProfile({
+            providerKey: jwtPayload.providerKey,
+            profile: {
+              id: jwtPayload.id,
+              email: jwtPayload.email
+            }
+          })
+          cb(null, user)
+        } catch (err) {
+          cb(err, null)
+        }
+      })
+    )
+  }
+}

--- a/server/modules/authentication/jwt/definition.yml
+++ b/server/modules/authentication/jwt/definition.yml
@@ -1,0 +1,15 @@
+key: jwt
+title: JWT
+description: Authenticate via JWT token
+author: Lilian Abiven
+logo: https://static.requarks.io/logo/wikijs.svg
+color: primary
+website: https://wiki.js.org
+isAvailable: true
+useForm: false
+props:
+  jwtSecret:
+    type: String
+    title: JWT secret
+    hint: JWT secret
+    order: 1


### PR DESCRIPTION
This module allows a user to authenticate using a jwt token containing a user id, an email and a generation date, for example:
```
{
  "id": "123",
  "email": "johndoe@example.com",
  "iat": 1516239022
}
```
The JWT secret is entered in the user interface. A token expires after 60 minutes, it could be a good idea to also make this duration configurable in the user interface.