### PR TITLE
Fix: Overwriting assert with the same name

### DIFF
--- a/server/controllers/upload.js
+++ b/server/controllers/upload.js
@@ -76,7 +76,8 @@ router.post('/u', (req, res, next) => {
   }
 
   // Sanitize filename
-  fileMeta.originalname = sanitize(fileMeta.originalname.toLowerCase().replace(/[\s,;#]+/g, '_'))
+  let time = new Date().getTime()
+  fileMeta.originalname = req.user.name + "_" + time + "_" + sanitize(fileMeta.originalname.toLowerCase().replace(/[\s,;#]+/g, '_'))
 
   // Check if user can upload at path
   const assetPath = (folderId) ? hierarchy.map(h => h.slug).join('/') + `/${fileMeta.originalname}` : fileMeta.originalname


### PR DESCRIPTION
Fix bug: As shown in #5599 and #5722, assert will be overwrited when uploading assert with the same name.

A simple way to solve the problem: Add username and unix time before the origin name.