### PR TITLE
fix map() call on undefined; fix unrelate() usage

### DIFF
--- a/server/modules/authentication/oidc/authentication.js
+++ b/server/modules/authentication/oidc/authentication.js
@@ -32,13 +32,13 @@ module.exports = {
           if (conf.mapGroups) {
             const groups = _.get(profile, '_json.' + conf.groupsClaim)
             if (groups && _.isArray(groups)) {
-              const currentGroups = (await user.$relatedQuery('groups').select('groups.id')).groups.map(g => g.id)
+              const currentGroups = (await user.$relatedQuery('groups').select('groups.id')).map(g => g.id)
               const expectedGroups = Object.values(WIKI.auth.groups).filter(g => groups.includes(g.name)).map(g => g.id)
               for (const groupId of _.difference(expectedGroups, currentGroups)) {
                 await user.$relatedQuery('groups').relate(groupId)
               }
               for (const groupId of _.difference(currentGroups, expectedGroups)) {
-                await user.$relatedQuery('groups').unrelate(groupId)
+                await user.$relatedQuery('groups').unrelate().where('groupId', groupId)
               }
             }
           }


### PR DESCRIPTION
The changes in v2.5.288 doesn't seem to be tested well. We use Keycloak via OIDC (because we need a group mapping which is absent in Keycloak provider) so I fixed it right in prod (yeah it's sort of things we always love). Sending a PR, hope the fix works for others.

1. `await user.$relatedQuery('groups').select('groups.id')` already returns a groups array, not an object with `groups` property.
2. unrelate() should be used with a where clause