### PR TITLE
Fix login with Keycloak 20 by explicit set OAuth scopes

### DIFF
--- a/server/modules/authentication/keycloak/authentication.js
+++ b/server/modules/authentication/keycloak/authentication.js
@@ -20,8 +20,7 @@ module.exports = {
         clientID: conf.clientId,
         clientSecret: conf.clientSecret,
         callbackURL: conf.callbackURL,
-        passReqToCallback: true,
-        scope: 'openid email profile'
+        passReqToCallback: true
       }, async (req, accessToken, refreshToken, profile, cb) => {
         let displayName = profile.username
         if (_.isString(profile.fullName) && profile.fullName.length > 0) {

--- a/server/modules/authentication/keycloak/authentication.js
+++ b/server/modules/authentication/keycloak/authentication.js
@@ -20,7 +20,8 @@ module.exports = {
         clientID: conf.clientId,
         clientSecret: conf.clientSecret,
         callbackURL: conf.callbackURL,
-        passReqToCallback: true
+        passReqToCallback: true,
+        scope: 'openid email profile'
       }, async (req, accessToken, refreshToken, profile, cb) => {
         let displayName = profile.username
         if (_.isString(profile.fullName) && profile.fullName.length > 0) {

--- a/server/modules/authentication/keycloak/definition.yml
+++ b/server/modules/authentication/keycloak/definition.yml
@@ -7,6 +7,10 @@ color: blue-grey darken-2
 website: https://www.keycloak.org/
 useForm: false
 isAvailable: true
+scopes:
+  - openid
+  - profile
+  - email
 props:
   host:
     type: String


### PR DESCRIPTION
Login failed after updating Keycloak to version 20.0.

Wiki.js showed the "Ooops, somethin went wrong" screen without any error details and Keycloak logged a unauthorized request to the `userinfo` resource.

A default `access_token` requested with an empty scope list may no longer get the OpenID user information. We can enable this by explicitly setting the scope to `openid email profile` to get the required data.

This issue was also described by @aurorasmiles  here: https://github.com/requarks/wiki/discussions/5805