### PR TITLE
Feature: KaTeX persistent macro support

### DIFF
--- a/client/components/editor/editor-markdown.vue
+++ b/client/components/editor/editor-markdown.vue
@@ -348,11 +348,12 @@ plantuml.init(md, {})
 // KATEX
 // ========================================
 
+const macros = {}
 md.inline.ruler.after('escape', 'katex_inline', katexHelper.katexInline)
 md.renderer.rules.katex_inline = (tokens, idx) => {
   try {
     return katex.renderToString(tokens[idx].content, {
-      displayMode: false
+      displayMode: false, macros
     })
   } catch (err) {
     console.warn(err)
@@ -365,7 +366,7 @@ md.block.ruler.after('blockquote', 'katex_block', katexHelper.katexBlock, {
 md.renderer.rules.katex_block = (tokens, idx) => {
   try {
     return `<p>` + katex.renderToString(tokens[idx].content, {
-      displayMode: true
+      displayMode: true, macros
     }) + `</p>`
   } catch (err) {
     console.warn(err)

--- a/server/modules/rendering/markdown-katex/renderer.js
+++ b/server/modules/rendering/markdown-katex/renderer.js
@@ -24,12 +24,13 @@ katex.__defineMacro('\\tripledash', '{\\vphantom{-}\\raisebox{2.56mu}{$\\mkern2m
 
 module.exports = {
   init (mdinst, conf) {
+    const macros = {}
     if (conf.useInline) {
       mdinst.inline.ruler.after('escape', 'katex_inline', katexInline)
       mdinst.renderer.rules.katex_inline = (tokens, idx) => {
         try {
           return katex.renderToString(tokens[idx].content, {
-            displayMode: false
+            displayMode: false, macros
           })
         } catch (err) {
           WIKI.logger.warn(err)
@@ -44,7 +45,7 @@ module.exports = {
       mdinst.renderer.rules.katex_block = (tokens, idx) => {
         try {
           return `<p>` + katex.renderToString(tokens[idx].content, {
-            displayMode: true
+            displayMode: true, macros
           }) + `</p>`
         } catch (err) {
           WIKI.logger.warn(err)


### PR DESCRIPTION
This PR allows user to define [macros](https://katex.org/docs/supported.html#macros) that persist over the page with the [`\gdef`](https://en.wikibooks.org/wiki/TeX/gdef) command.

![firefox_HC0WJsGvye](https://user-images.githubusercontent.com/13620400/201412460-aac0dfb9-aebd-4d81-9b9c-12bef3f41056.png)

Reference: https://katex.org/docs/api.html#persistent-macros