### PR TITLE
feat: add artalk comment module

### DIFF
--- a/server/modules/comments/artalk/code.yml
+++ b/server/modules/comments/artalk/code.yml
@@ -1,14 +1,14 @@
 main: |
-  <div id="Comments"></div>
+  <div id="artalk-container"></div>
 head: |
-  <link href="https://unpkg.com/artalk/dist/Artalk.css" rel="stylesheet">
-  <script src="https://unpkg.com/artalk/dist/Artalk.js"></script>
+  <link href="{{server}}/dist/Artalk.css" rel="stylesheet">
+  <script src="{{server}}/dist/Artalk.js"></script>
 body: |
   <script>
     window.onload = function() {
       new Artalk({
-        el:        '#Comments',
-        pageKey:   '',
+        el:        '#artalk-container',
+        pageKey:   '{{pageId}}',
         pageTitle: '',
         server:    '{{server}}',
         site:      '{{siteName}}',

--- a/server/modules/comments/artalk/code.yml
+++ b/server/modules/comments/artalk/code.yml
@@ -1,0 +1,17 @@
+main: |
+  <div id="Comments"></div>
+head: |
+  <link href="https://unpkg.com/artalk/dist/Artalk.css" rel="stylesheet">
+  <script src="https://unpkg.com/artalk/dist/Artalk.js"></script>
+body: |
+  <script>
+    window.onload = function() {
+      new Artalk({
+        el:        '#Comments',
+        pageKey:   '',
+        pageTitle: '',
+        server:    '{{server}}',
+        site:      '{{siteName}}',
+      });
+    };
+  </script>

--- a/server/modules/comments/artalk/definition.yml
+++ b/server/modules/comments/artalk/definition.yml
@@ -2,7 +2,7 @@ key: artalk
 title: Artalk
 description: A light-weight self-hosted comment system.
 author: CDN18
-logo: https://artalk.js.org/favicon.png
+logo: https://static.requarks.io/logo/artalk.png
 website: https://artalk.js.org
 codeTemplate: true
 isAvailable: true
@@ -11,7 +11,7 @@ props:
     type: String
     title: Artalk Backend URL
     default: ''
-    hint: 'Publicly accessible URL of your Artalk instance. Protocol header (http/https) is required.'
+    hint: 'Publicly accessible URL of your Artalk instance. It should start with http/https and omit the trailing slash. (e.g. https://artalk.example.com)'
     maxWidth: 650
     order: 1
   siteName:

--- a/server/modules/comments/artalk/definition.yml
+++ b/server/modules/comments/artalk/definition.yml
@@ -1,0 +1,23 @@
+key: artalk
+title: Artalk
+description: A light-weight self-hosted comment system.
+author: CDN18
+logo: https://artalk.js.org/favicon.png
+website: https://artalk.js.org
+codeTemplate: true
+isAvailable: true
+props:
+  server:
+    type: String
+    title: Artalk Backend URL
+    default: ''
+    hint: 'Publicly accessible URL of your Artalk instance. Protocol header (http/https) is required.'
+    maxWidth: 650
+    order: 1
+  siteName:
+    type: String
+    title: Site Name
+    default: ''
+    hint: 'The name of this site configured in the artalk backend. Leave empty to use default site.'
+    maxWidth: 450
+    order: 2


### PR DESCRIPTION
This module integrates [Artalk](https://artalk.js.org), a self-hosted comment system to the comment section.