### PR TITLE
fix: keycloak authentication post logout redirect for Keycloak 18+

### DIFF
--- a/server/models/users.js
+++ b/server/models/users.js
@@ -866,7 +866,7 @@ module.exports = class User extends Model {
     }
     const usr = await WIKI.models.users.query().findById(context.req.user.id).select('providerKey')
     const provider = _.find(WIKI.auth.strategies, ['key', usr.providerKey])
-    return provider.logout ? provider.logout(provider.config) : '/'
+    return provider.logout ? provider.logout(provider.config, context) : '/'
   }
 
   static async getGuestUser () {

--- a/server/modules/authentication/keycloak/definition.yml
+++ b/server/modules/authentication/keycloak/definition.yml
@@ -57,4 +57,9 @@ props:
     title: Logout Endpoint URL
     hint: e.g. https://KEYCLOAK-HOST/auth/realms/YOUR-REALM/protocol/openid-connect/logout
     order: 9
+  logoutUpstreamRedirectLegacy:
+    type: Boolean
+    title: Legacy Logout Redirect
+    hint: Pass the legacy 'redirect_uri' parameter to the logout endpoint. Leave disabled for Keycloak 18 and above.
+    order: 10
 


### PR DESCRIPTION
## What?

This fixes the Keycloak authentication strategy post logout redirect from Keycloak 18 and above when 'Logout from Keycloak on Logout' is enabled. Additionally, a new parameter has been added to the strategy config to enable the old behavior for legacy versions of Keycloak.

This was brought up in discussion #5213 and partially addressed in unmerged #5513. That PR fixes the logout error in Keycloak 18+, but doesn't provide a redirect back to the wiki.

## Why?

In older versions of Keycloak, the 'redirect_uri' parameter can be passed to the logout endpoint to automatically log out and redirect afterwards. Starting with Keycloak 18, this has been replaced with 'post_logout_redirect_uri'. This parameter must be accompanied by 'id_token_hint' with its value set to the id_token obtained at login.

## How?

The id_token from Keycloak is saved to the user's session upon successful authentication and added as 'id_token_hint' when generating the post logout redirect. Enabling 'Legacy Logout Redirect' in the strategy config will revert to the old behavior of using only 'redirect_uri'.