### PR TITLE
fix: `git log` should explicitly separate branch from paths

### DIFF
--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -118,7 +118,7 @@ module.exports = {
    * SYNC
    */
   async sync() {
-    const currentCommitLog = _.get(await this.git.log(['-n', '1', this.config.branch]), 'latest', {})
+    const currentCommitLog = _.get(await this.git.log(['-n', '1', this.config.branch, '--']), 'latest', {})
 
     const rootUser = await WIKI.models.users.getRootUser()
 
@@ -140,7 +140,7 @@ module.exports = {
 
     // Process Changes
     if (_.includes(['sync', 'pull'], this.mode)) {
-      const latestCommitLog = _.get(await this.git.log(['-n', '1', this.config.branch]), 'latest', {})
+      const latestCommitLog = _.get(await this.git.log(['-n', '1', this.config.branch, '--']), 'latest', {})
 
       const diff = await this.git.diffSummary(['-M', currentCommitLog.hash, latestCommitLog.hash])
       if (_.get(diff, 'files', []).length > 0) {


### PR DESCRIPTION
The git storage module will encounter an error when a file with the same branch name exists in the root directory of the repo.

```
fatal: ambiguous argument 'branch_name': both revision and filename
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

This pull request will fix the problem by adding `--` after the `this.config.branch` param of  the `git log` command.