### PR TITLE
feat: sideloader can import availabilities

### DIFF
--- a/server/core/sideloader.js
+++ b/server/core/sideloader.js
@@ -53,7 +53,7 @@ module.exports = {
                   isRTL: locale.isRTL,
                   name: locale.name,
                   nativeName: locale.nativeName,
-                  availability: locale.availability ?? 0
+                  availability: locale.availability || 0
                 }).where('code', locale.code)
               } else {
                 await WIKI.models.locales.query().insert({
@@ -62,7 +62,7 @@ module.exports = {
                   isRTL: locale.isRTL,
                   name: locale.name,
                   nativeName: locale.nativeName,
-                  availability: locale.availability ?? 0
+                  availability: locale.availability || 0
                 })
               }
               importedLocales++

--- a/server/core/sideloader.js
+++ b/server/core/sideloader.js
@@ -5,72 +5,74 @@ const _ = require('lodash')
 /* global WIKI */
 
 module.exports = {
-  async init () {
-    if (!WIKI.config.offline) {
-      return
-    }
-
-    const sideloadExists = await fs.pathExists(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload'))
-
-    if (!sideloadExists) {
-      return
-    }
-
-    WIKI.logger.info('Sideload directory detected. Looking for packages...')
-
-    try {
-      await this.importLocales()
-    } catch (err) {
-      WIKI.logger.warn(err)
-    }
-  },
-  async importLocales() {
-    const localeExists = await fs.pathExists(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload/locales.json'))
-    if (localeExists) {
-      WIKI.logger.info('Found locales master file. Importing locale packages...')
-      let importedLocales = 0
-
-      const locales = await fs.readJson(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload/locales.json'))
-      if (locales && _.has(locales, 'data.localization.locales')) {
-        for (const locale of locales.data.localization.locales) {
-          try {
-            const localeData = await fs.readJson(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `sideload/${locale.code}.json`))
-            if (localeData) {
-              WIKI.logger.info(`Importing ${locale.name} locale package...`)
-
-              let lcObj = {}
-              _.forOwn(localeData, (value, key) => {
-                if (_.includes(key, '::')) { return }
-                if (_.isEmpty(value)) { value = key }
-                _.set(lcObj, key.replace(':', '.'), value)
-              })
-
-              const localeDbExists = await WIKI.models.locales.query().select('code').where('code', locale.code).first()
-              if (localeDbExists) {
-                await WIKI.models.locales.query().update({
-                  code: locale.code,
-                  strings: lcObj,
-                  isRTL: locale.isRTL,
-                  name: locale.name,
-                  nativeName: locale.nativeName
-                }).where('code', locale.code)
-              } else {
-                await WIKI.models.locales.query().insert({
-                  code: locale.code,
-                  strings: lcObj,
-                  isRTL: locale.isRTL,
-                  name: locale.name,
-                  nativeName: locale.nativeName
-                })
-              }
-              importedLocales++
-            }
-          } catch (err) {
-            // skip
-          }
+    async init () {
+        if (!WIKI.config.offline) {
+            return
         }
-        WIKI.logger.info(`Imported ${importedLocales} locale packages: [COMPLETED]`)
-      }
+
+        const sideloadExists = await fs.pathExists(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload'))
+
+        if (!sideloadExists) {
+            return
+        }
+
+        WIKI.logger.info('Sideload directory detected. Looking for packages...')
+
+        try {
+            await this.importLocales()
+        } catch (err) {
+            WIKI.logger.warn(err)
+        }
+    },
+    async importLocales() {
+        const localeExists = await fs.pathExists(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload/locales.json'))
+        if (localeExists) {
+            WIKI.logger.info('Found locales master file. Importing locale packages...')
+            let importedLocales = 0
+
+            const locales = await fs.readJson(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload/locales.json'))
+            if (locales && _.has(locales, 'data.localization.locales')) {
+                for (const locale of locales.data.localization.locales) {
+                    try {
+                        const localeData = await fs.readJson(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `sideload/${locale.code}.json`))
+                        if (localeData) {
+                            WIKI.logger.info(`Importing ${locale.name} locale package...`)
+
+                            let lcObj = {}
+                            _.forOwn(localeData, (value, key) => {
+                                if (_.includes(key, '::')) { return }
+                                if (_.isEmpty(value)) { value = key }
+                                _.set(lcObj, key.replace(':', '.'), value)
+                            })
+
+                            const localeDbExists = await WIKI.models.locales.query().select('code').where('code', locale.code).first()
+                            if (localeDbExists) {
+                                await WIKI.models.locales.query().update({
+                                    code: locale.code,
+                                    strings: lcObj,
+                                    isRTL: locale.isRTL,
+                                    name: locale.name,
+                                    nativeName: locale.nativeName,
+                                    availability: locale.availability ?? 0
+                                }).where('code', locale.code)
+                            } else {
+                                await WIKI.models.locales.query().insert({
+                                    code: locale.code,
+                                    strings: lcObj,
+                                    isRTL: locale.isRTL,
+                                    name: locale.name,
+                                    nativeName: locale.nativeName,
+                                    availability: locale.availability ?? 0
+                                })
+                            }
+                            importedLocales++
+                        }
+                    } catch (err) {
+                        // skip
+                    }
+                }
+                WIKI.logger.info(`Imported ${importedLocales} locale packages: [COMPLETED]`)
+            }
+        }
     }
-  }
 }

--- a/server/core/sideloader.js
+++ b/server/core/sideloader.js
@@ -5,74 +5,74 @@ const _ = require('lodash')
 /* global WIKI */
 
 module.exports = {
-    async init () {
-        if (!WIKI.config.offline) {
-            return
-        }
-
-        const sideloadExists = await fs.pathExists(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload'))
-
-        if (!sideloadExists) {
-            return
-        }
-
-        WIKI.logger.info('Sideload directory detected. Looking for packages...')
-
-        try {
-            await this.importLocales()
-        } catch (err) {
-            WIKI.logger.warn(err)
-        }
-    },
-    async importLocales() {
-        const localeExists = await fs.pathExists(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload/locales.json'))
-        if (localeExists) {
-            WIKI.logger.info('Found locales master file. Importing locale packages...')
-            let importedLocales = 0
-
-            const locales = await fs.readJson(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload/locales.json'))
-            if (locales && _.has(locales, 'data.localization.locales')) {
-                for (const locale of locales.data.localization.locales) {
-                    try {
-                        const localeData = await fs.readJson(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `sideload/${locale.code}.json`))
-                        if (localeData) {
-                            WIKI.logger.info(`Importing ${locale.name} locale package...`)
-
-                            let lcObj = {}
-                            _.forOwn(localeData, (value, key) => {
-                                if (_.includes(key, '::')) { return }
-                                if (_.isEmpty(value)) { value = key }
-                                _.set(lcObj, key.replace(':', '.'), value)
-                            })
-
-                            const localeDbExists = await WIKI.models.locales.query().select('code').where('code', locale.code).first()
-                            if (localeDbExists) {
-                                await WIKI.models.locales.query().update({
-                                    code: locale.code,
-                                    strings: lcObj,
-                                    isRTL: locale.isRTL,
-                                    name: locale.name,
-                                    nativeName: locale.nativeName,
-                                    availability: locale.availability ?? 0
-                                }).where('code', locale.code)
-                            } else {
-                                await WIKI.models.locales.query().insert({
-                                    code: locale.code,
-                                    strings: lcObj,
-                                    isRTL: locale.isRTL,
-                                    name: locale.name,
-                                    nativeName: locale.nativeName,
-                                    availability: locale.availability ?? 0
-                                })
-                            }
-                            importedLocales++
-                        }
-                    } catch (err) {
-                        // skip
-                    }
-                }
-                WIKI.logger.info(`Imported ${importedLocales} locale packages: [COMPLETED]`)
-            }
-        }
+  async init () {
+    if (!WIKI.config.offline) {
+      return
     }
+
+    const sideloadExists = await fs.pathExists(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload'))
+
+    if (!sideloadExists) {
+      return
+    }
+
+    WIKI.logger.info('Sideload directory detected. Looking for packages...')
+
+    try {
+      await this.importLocales()
+    } catch (err) {
+      WIKI.logger.warn(err)
+    }
+  },
+  async importLocales() {
+    const localeExists = await fs.pathExists(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload/locales.json'))
+    if (localeExists) {
+      WIKI.logger.info('Found locales master file. Importing locale packages...')
+      let importedLocales = 0
+
+      const locales = await fs.readJson(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, 'sideload/locales.json'))
+      if (locales && _.has(locales, 'data.localization.locales')) {
+        for (const locale of locales.data.localization.locales) {
+          try {
+            const localeData = await fs.readJson(path.resolve(WIKI.ROOTPATH, WIKI.config.dataPath, `sideload/${locale.code}.json`))
+            if (localeData) {
+              WIKI.logger.info(`Importing ${locale.name} locale package...`)
+
+              let lcObj = {}
+              _.forOwn(localeData, (value, key) => {
+                if (_.includes(key, '::')) { return }
+                if (_.isEmpty(value)) { value = key }
+                _.set(lcObj, key.replace(':', '.'), value)
+              })
+
+              const localeDbExists = await WIKI.models.locales.query().select('code').where('code', locale.code).first()
+              if (localeDbExists) {
+                await WIKI.models.locales.query().update({
+                  code: locale.code,
+                  strings: lcObj,
+                  isRTL: locale.isRTL,
+                  name: locale.name,
+                  nativeName: locale.nativeName,
+                  availability: locale.availability ?? 0
+                }).where('code', locale.code)
+              } else {
+                await WIKI.models.locales.query().insert({
+                  code: locale.code,
+                  strings: lcObj,
+                  isRTL: locale.isRTL,
+                  name: locale.name,
+                  nativeName: locale.nativeName,
+                  availability: locale.availability ?? 0
+                })
+              }
+              importedLocales++
+            }
+          } catch (err) {
+            // skip
+          }
+        }
+        WIKI.logger.info(`Imported ${importedLocales} locale packages: [COMPLETED]`)
+      }
+    }
+  }
 }


### PR DESCRIPTION
We have a setup with kubernetes where external communication is not allowed. So our solution for localization was to use the offline mode and build a custom image from the base Wiki.js image, where we preload the localization files during the build process of the image. This way works fine, but in the admin ui we can not see the availability of each locale because this information would normally be loaded from the GraphQL endpoint which is of course blocked in our environment.
Our approach currently loads the localization files at the build time of the docker image from the GraphQL endpoint, but the sideloader doesn't support importing the availabilities from the locales. So maybe this extension of the sideloader would be helpful for others who have the same problem.