### PR TITLE
feat: add singleByPath for page query

### DIFF
--- a/server/graph/resolvers/page.js
+++ b/server/graph/resolvers/page.js
@@ -170,6 +170,30 @@ module.exports = {
         throw new WIKI.Error.PageNotFound()
       }
     },
+    async singleByPath(obj, args, context, info) {
+      let page = await WIKI.models.pages.getPageFromDb({
+        path: args.path,
+        locale: args.locale,
+      });
+      if (page) {
+        if (WIKI.auth.checkAccess(context.req.user, ['manage:pages', 'delete:pages'], {
+          path: page.path,
+          locale: page.localeCode
+        })) {
+          return {
+            ...page,
+            locale: page.localeCode,
+            editor: page.editorKey,
+            scriptJs: page.extra.js,
+            scriptCss: page.extra.css
+          }
+        } else {
+          throw new WIKI.Error.PageViewForbidden()
+        }
+      } else {
+        throw new WIKI.Error.PageNotFound()
+      }
+    },
     /**
      * FETCH TAGS
      */

--- a/server/graph/schemas/page.graphql
+++ b/server/graph/schemas/page.graphql
@@ -46,6 +46,11 @@ type PageQuery {
     id: Int!
   ): Page @auth(requires: ["read:pages", "manage:system"])
 
+  singleByPath(
+    path: String!
+    locale: String!
+  ): Page @auth(requires: ["read:pages", "manage:system"])
+
   tags: [PageTag]! @auth(requires: ["manage:system", "read:pages"])
 
   searchTags(


### PR DESCRIPTION
adding a user friendly of getting a page. If I want to get find a page by text, I have to do 2 query. One for the id and then using single.