### PR TITLE
git storage: disable color.ui

### DIFF
--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -45,9 +45,10 @@ module.exports = {
       await this.git.init()
     }
 
-    // Disable quotePath
+    // Disable quotePath, color output
     // Link https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath
     await this.git.raw(['config', '--local', 'core.quotepath', false])
+    await this.git.raw(['config', '--local', 'color.ui', false])
 
     // Set default author
     await this.git.raw(['config', '--local', 'user.email', this.config.defaultEmail])


### PR DESCRIPTION
If Git's `color.ui` has been set to "always" globally, the git storage module will fail to sync because `branches.all` will contain "\u001b[31mremotes/origin/master\u001b[m" instead of "remotes/origin/master", as revealed by `WIKI.logger.info(JSON.stringify(branches.all[0]))`.