### PR TITLE
Prevent overwriting of uploaded pasted images

### DIFF
--- a/server/controllers/upload.js
+++ b/server/controllers/upload.js
@@ -78,6 +78,11 @@ router.post('/u', (req, res, next) => {
   // Sanitize filename
   fileMeta.originalname = sanitize(fileMeta.originalname.toLowerCase().replace(/[\s,;#]+/g, '_'))
 
+  // Prevent overwriting of pasted images
+  if (fileMeta.originalname == 'image.png') {
+    fileMeta.originalname = 'image_' + Date.now() + '.png'
+  }
+
   // Check if user can upload at path
   const assetPath = (folderId) ? hierarchy.map(h => h.slug).join('/') + `/${fileMeta.originalname}` : fileMeta.originalname
   if (!WIKI.auth.checkAccess(req.user, ['write:assets'], { path: assetPath })) {


### PR DESCRIPTION
Problem:
This issue has been discussed in the forum for the MD editor but is also present in the WYSIWYG editor as well. 
Discussion: https://feedback.js.wiki/wiki/p/ability-to-paste-images-into-md-editor

Images that are pasted into the application all have the filename `image.png`. 

Solution:
This PR appends the current timestamp to the image name to ensure there is no overlap in the filename and allows for uploads to occur without overwriting existing uploads.


Why:
This is a very important feature for those who use this application for documentation as most developers use screenshots on their pages. Having to save screenshots and selecting them from the local system is time-consuming and inhibits application usage.