### PR TITLE
git storage: handle file renames between folders

### DIFF
--- a/server/core/db.js
+++ b/server/core/db.js
@@ -138,7 +138,7 @@ module.exports = {
           switch (WIKI.config.db.type) {
             case 'postgres':
               await conn.query(`set application_name = 'Wiki.js'`)
-              // -> Set schema if it's not public             
+              // -> Set schema if it's not public
               if (WIKI.config.db.schema && WIKI.config.db.schema !== 'public') {
                 await conn.query(`set search_path TO ${WIKI.config.db.schema}, public;`)
               }

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -725,7 +725,7 @@ module.exports = class Page extends Model {
     const destinationHash = pageHelper.generateHash({ path: opts.destinationPath, locale: opts.destinationLocale, privateNS: opts.isPrivate ? 'TODO' : '' })
 
     // -> Move page
-    const destinationTitle = (page.title === page.path ? opts.destinationPath : page.title)
+    const destinationTitle = (page.title === _.last(page.path.split('/')) ? _.last(opts.destinationPath.split('/')) : page.title)
     await WIKI.models.pages.query().patch({
       path: opts.destinationPath,
       localeCode: opts.destinationLocale,
@@ -745,6 +745,7 @@ module.exports = class Page extends Model {
       ...page,
       destinationPath: opts.destinationPath,
       destinationLocaleCode: opts.destinationLocale,
+      title: destinationTitle,
       destinationHash
     })
 

--- a/server/modules/storage/disk/storage.js
+++ b/server/modules/storage/disk/storage.js
@@ -135,7 +135,7 @@ module.exports = {
         transform: async (page, enc, cb) => {
           const pageObject = await WIKI.models.pages.query().findById(page.id)
           page.tags = await pageObject.$relatedQuery('tags')
-          
+
           let fileName = `${page.path}.${pageHelper.getFileExtension(page.contentType)}`
           if (WIKI.config.lang.code !== page.localeCode) {
             fileName = `${page.localeCode}/${fileName}`

--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -148,24 +148,20 @@ module.exports = {
         const filePattern = /(.*?)(?:{(.*?))? => (?:(.*?)})?(.*)/
         for (const f of diff.files) {
           const fMatch = f.file.match(filePattern)
-          const fNames = function () {
-            if (!fMatch) {
-              return {
-                "old":f.file,
-                "new":f.file
-              }
-            } else if (!fMatch[2] && !fMatch[3]) {
-              return {
-                "old":fMatch[1],
-                "new":fMatch[4]
-              }
-            } else {
-              return {
-                "old":(fMatch[1]+fMatch[2]+fMatch[4]).replace('//', '/'),
-                "new":(fMatch[1]+fMatch[3]+fMatch[4]).replace('//', '/')
-              }
-            }
-          }()
+          const fNames = {
+            old: null,
+            new: null
+          }
+          if (!fMatch) {
+            fNames.old = f.file
+            fNames.new = f.file
+          } else if (!fMatch[2] && !fMatch[3]) {
+            fNames.old = fMatch[1]
+            fNames.new = fMatch[4]
+          } else {
+            fNames.old = (fMatch[1]+fMatch[2]+fMatch[4]).replace('//', '/'),
+            fNames.new = (fMatch[1]+fMatch[3]+fMatch[4]).replace('//', '/')
+          }
           const fPath = path.join(this.repoPath, fNames.new)
           let fStats = { size: 0 }
           try {


### PR DESCRIPTION
I've discovered that my implementation of handling moved or renamed files for git storage in #4307 was incomplete. It turns out that if the old and new file paths have common elements, `git diff --stat -M <hash-before> <hash-after>` (called by `this.git.diffSummary`) will display them in a compressed format using braces. This commit updates the logic to handle all the non-renaming, simple renaming, and compressed renaming formats that I was able to find. Examples are below:
```
// edit top level file
file.md
// rename top level file
file.md => index.md
// move file to folder
index.md => folder/index.md
// rename folder, or move file between folders
{folder => directory}/index.md
// rename file in folder
directory/{index.md => subindex.md}
// move file to subfolder
directory/{ => subdir}/subindex.md
// rename subfolder, or move file between subfolders
directory/{subdir => subdirectory}/subindex.md
// move file from subfolder
directory/{subdirectory => }/subindex.md
// move and rename file to subfolder
directory/{subindex.md => subdirectory/sub-index.md}
// move and rename file between subfolders
directory/{subdirectory/sub-index.md => subdir/subdir-index.md}
// move and rename file from subfolder
directory/{subdir/subdir-index.md => dir-index.md}
// move and rename file between folders
directory/dir-index.md => other/other-index.md
// move and rename file to top level
other/other-index.md => home.md
```
This also updates the `destinationTitle` logic to better detect and update page titles that have not been updated since being auto-generated from the page's path, which originally worked only for top-level pages. 

This should fix the behaviour observed in #4701 and potentially #4677.