### PR TITLE
Id instead of path for pages

### DIFF
--- a/client/components/editor.vue
+++ b/client/components/editor.vue
@@ -364,7 +364,7 @@ export default {
             this.$store.set('editor/id', _.get(resp, 'page.id'))
             this.$store.set('editor/mode', 'update')
             this.exitConfirmed = true
-            window.location.assign(`/${this.$store.get('page/locale')}/${this.$store.get('page/path')}`)
+            window.location.assign(`/${this.$store.get('page/locale')}/${_.get(resp, 'page.id')}`)
           } else {
             throw new Error(_.get(resp, 'responseResult.message'))
           }

--- a/client/components/editor/editor-markdown.vue
+++ b/client/components/editor/editor-markdown.vue
@@ -679,10 +679,10 @@ export default {
     insertLink () {
       this.insertLinkDialog = true
     },
-    insertLinkHandler ({ locale, path }) {
+    insertLinkHandler ({ locale, path, pageId }) {
       const lastPart = _.last(path.split('/'))
       this.insertAtCursor({
-        content: siteLangs.length > 0 ? `[${lastPart}](/${locale}/${path})` : `[${lastPart}](/${path})`
+        content: `[${lastPart}](/${locale}/${pageId})`
       })
     },
     processMarkers (from, to) {

--- a/server/controllers/common.js
+++ b/server/controllers/common.js
@@ -119,12 +119,22 @@ router.get(['/e', '/e/*'], async (req, res, next) => {
   }
 
   // -> Get page data from DB
-  let page = await WIKI.models.pages.getPageFromDb({
-    path: pageArgs.path,
-    locale: pageArgs.locale,
-    userId: req.user.id,
-    isPrivate: false
-  })
+  let page;
+
+  try {
+    if (pageArgs.path && _.isNumber(pageArgs.path)) {
+      page = await WIKI.models.pages.getPage(+pageArgs.path);
+    } else {
+      page = await WIKI.models.pages.getPage({
+        path: pageArgs.path,
+        locale: pageArgs.locale,
+        userId: req.user.id,
+        isPrivate: false
+      })
+    }
+  } catch (error) {
+    console.error(error);
+  }
 
   pageArgs.tags = _.get(page, 'tags', [])
 


### PR DESCRIPTION
I suggest using the id in the router instead of the path, because at the moment there are problems using the path (for example, when moving a page, links to this page do not change) and this solution will be resolve a lot of problems in the future