### PR TITLE
fix: Helm Chart - Sideloading

### DIFF
--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
           command: [ "sh", "-c" ]
           args: [ "mkdir -p /wiki/data/sideload && git clone --depth=1 {{ .Values.sideload.repoURL }} /wiki/data/sideload/" ]
       {{- end }}
+    {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -71,6 +75,8 @@ spec:
             {{- end }}
             - name: HA_ACTIVE
               value: {{ .Values.replicaCount | int | le 2 | quote }}
+            - name: OFFLINE_ACTIVE
+              value: "{{ default "false" .Values.offline }}"
     {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 revisionHistoryLimit: 10
+# If sideload is enable, set the offline parameter to true
+offline: false
 
 image:
   repository: requarks/wiki


### PR DESCRIPTION
Context : Wiki container is isolated from the internet, so i enabled sideloading.

Problems : 

1. The init container don't have volumeMounts, so wiki container can't get the locales files previously downloaded.
2. Wiki container don't use locales files in "sideload" folder because we can't set the option "offline" to true.

Fixs : 

1. Added volumeMounts for the init container, for mount an "emptyDir" with the wiki container, for example.
2. 
- Added var "OFFLINE_ACTIVE" for set offline option.
- Added offline var in values.yaml

**NB :** Implies to add "offline: $(OFFLINE_ACTIVE)" into /wiki/config.yml in the docker image.
