### PR TITLE
Gitpod support to vega

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -41,6 +41,23 @@ ports:
     port: 5432
     onOpen: ignore
 
+github:
+  prebuilds:
+    # enable for the default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: true
+
 vscode:
   extensions:
     - dbaeumer.vscode-eslint

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,43 @@
+image: gitpod/workspace-postgres
+
+tasks:
+  - name: Yarn Server - legacy:build
+    init: >
+      cp config.sample.yml config.yml &&
+      nvm install v18.13 &&
+      yarn install &&
+      yarn legacy:build &&
+      gp sync-done build-legacy &&
+      pg_start &&
+      gp sync-await build
+    command:  yarn dev
+    openMode: split-left
+
+  - name: Yarn UX - build
+    init: >
+      gp sync-await build-legacy &&
+      yarn build &&
+      gp sync-done build
+    openMode: split-right
+
+ports:
+  - name: Web App
+    port: 5000
+    description: The main application web server
+    visibility: private
+    onOpen: open-browser
+  - name: pgAdmin
+    description: a PostgreSQL administration tool. Use the login dev / 123123 to login.
+    port: 8000
+    visibility: private
+    onOpen: ignore
+  - name: postgresql Server
+    port: 5432
+    onOpen: ignore
+
+vscode:
+  extensions:
+    - dbaeumer.vscode-eslint
+    - EditorConfig.EditorConfig
+    - christian-kohler.path-intellisense
+    - octref.vetur

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,7 +8,6 @@ tasks:
       yarn install &&
       yarn legacy:build &&
       gp sync-done build-legacy &&
-      pg_start &&
       gp sync-await build
     command:  yarn dev
     openMode: split-left
@@ -16,16 +15,23 @@ tasks:
   - name: Yarn UX - build
     init: >
       gp sync-await build-legacy &&
+      cd ux &&
+      yarn install &&
       yarn build &&
       gp sync-done build
+    command: yarn dev
     openMode: split-right
 
 ports:
   - name: Web App
-    port: 5000
-    description: The main application web server
+    port: 3000
+    description: The main application web server. Use the login admin@example.com / 12345678 to login.
     visibility: private
     onOpen: open-browser
+  - name: UX dev
+    port: 3001
+    visibility: private
+    onOpen: ignore
   - name: pgAdmin
     description: a PostgreSQL administration tool. Use the login dev / 123123 to login.
     port: 8000

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Twitter Follow](https://img.shields.io/badge/follow-%40requarks-blue.svg?style=flat&logo=twitter)](https://twitter.com/requarks)
 [![Reddit](https://img.shields.io/badge/reddit-%2Fr%2Fwikijs-orange?logo=reddit&logoColor=white)](https://www.reddit.com/r/wikijs/)
 [![Subscribe to Newsletter](https://img.shields.io/badge/newsletter-subscribe-yellow.svg?style=flat&logo=mailchimp)](https://blog.js.wiki/subscribe)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-908a85?logo=gitpod)](https://gitpod.io/from-referrer/)
 
 ##### Next Generation Open Source Wiki
 
@@ -30,6 +31,7 @@ The current stable release (2.x) is available at https://js.wiki
 - [Generic Setup](#generic-setup)
   - [Requirements](#requirements)
   - [Usage](#usage)
+- [Using VS Code DEV Environment by GitPod.io](#using-cs-code-dev-environment-by-gitpodio)
 - [Using VS Code Dev Environment](#using-vs-code-dev-environment) *(recommended)*
   - [Requirements](#requirements-1)
   - [Usage](#usage-1)
@@ -74,6 +76,12 @@ The current stable release (2.x) is available at https://js.wiki
     - Password: `12345678`
 
 > **DO NOT** report bugs. This build is **VERY** buggy and **VERY** incomplete. Absolutely **NO** support is provided either.
+
+## Using CS Code Dev Environment by Gitpod.io
+
+Gitpod is an open-source Kubernetes application for ready-to-code cloud development environments that spins up fresh, automated dev environments for each task, in the cloud, in seconds. It enables you to describe your dev environment as code and start instant, remote and cloud development environments directly from your browser or your Desktop IDE.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ## Using VS Code Dev Environment
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - **[Official Website](https://next.js.wiki/)**
 - **[Documentation](https://next.js.wiki/docs/)**
 
-:red_square: :warning: :warning: :red_square:   
+:red_square: :warning: :warning: :red_square:
 **THIS IS A VERY BUGGY, INCOMPLETE AND NON-SECURE DEVELOPMENT BRANCH!**  
 **USE AT YOUR OWN RISK! THERE'S NO UPGRADE PATH FROM THIS BUILD AND NO SUPPORT IS PROVIDED!**  
 :red_square: :warning: :warning: :red_square:
@@ -52,6 +52,7 @@ The current stable release (2.x) is available at https://js.wiki
 1. Make a copy of `config.sample.yml` and rename it to `config.yml`
 1. Edit `config.yml` and fill in the database details. **You need an empty PostgreSQL database.**
 1. Run the following commands to install dependencies and generate the client assets:
+
     ```sh
     yarn
     yarn legacy:build
@@ -60,11 +61,14 @@ The current stable release (2.x) is available at https://js.wiki
     yarn build
     cd ..
     ```
+
 1. Run this command to start the server:
+
     ```sh
     node server
     ```
-1. In your browser, navigate to `http://localhost:5000` *(or the IP/hostname of the server and the PORT you defined earlier.)*
+
+1. In your browser, navigate to `http://localhost:3000` *(or the IP/hostname of the server and the PORT you defined earlier.)*
 1. Login using the default administrator user:
     - Email: `admin@example.com`
     - Password: `12345678`
@@ -92,18 +96,24 @@ The current stable release (2.x) is available at https://js.wiki
     - Select the task "Create terminals" and press Enter
 1. Two terminals will launch in split-screen mode at the bottom of the screen. **Server** on the left and **UX** on the right.
 1. In the left-side terminal (Server), run the command:
+
     ```sh
     yarn legacy:build
     ```
+
 1. In the right-side terminal (UX), run the command:
+
     ```sh
     yarn build
     ```
+
 1. Back in the left-side terminal (Server), run the command:
+
     ```sh
     yarn dev
     ```
-1. Open your browser to `http://localhost:5000`
+
+1. Open your browser to `http://localhost:3000`
 1. Login using the default administrator user:
     - Email: `admin@example.com`
     - Password: `12345678`
@@ -132,17 +142,18 @@ If you wish to modify any frontend content (under `/ux`), you need to start the 
 yarn dev
 ```
 
-You can then access the site at `http://localhost:5001`. Notice the port being `5001` rather than `5000`. The app runs in a SPA (single-page application) mode and automatically hot-reload any modified component. Any requests made to the `/graphql` endpoint are automatically forwarded to the server running on port `5000`, which is why both must be running at the same time.
+You can then access the site at `http://localhost:3001`. Notice the port being `3001` rather than `3000`. The app runs in a SPA (single-page application) mode and automatically hot-reload any modified component. Any requests made to the `/graphql` endpoint are automatically forwarded to the server running on port `3000`, which is why both must be running at the same time.
 
 Note that not all sections/features are available from this mode, notably the page editing features which still relies on the old client code (Vuetify/Vue 2). For example, trying to edit a page will simply not work. You must use the normal mode (port 5000) to edit pages as it relies on legacy client code. As more features gets ported / developed for Vue 3, they will become available in the SPA mode.
 
-Any change you make to the frontend will not be reflected on port 5000 until you run the command `yarn build` in the right-side terminal.
+Any change you make to the frontend will not be reflected on port `3000` until you run the command `yarn build` in the right-side terminal.
 
 ### Legacy Frontend Development (Vuetify/Vue 2)
 
 Client code from Wiki.js 2.x is located under `/client`. Some sections still rely on this legacy code (notably the page editing features). Code is gradually being removed from this location and replaced with newer code in `/ux`.
 
 In the unlikely event that you need to modify legacy code and regenerate the old client files, you can do so by running in this command in the left-side terminal (Server):
+
 ```sh
 yarn legacy:build
 ```


### PR DESCRIPTION
With Gitpod support, vega can be launched directly in a Gitpod.io workspace in the cloud. A local development environment is not required for this.

GitPod can be used free of charge for 50 hours per month.