### PR TITLE
Adds displayName property to oidc authentication method

### DIFF
--- a/server/modules/authentication/oidc/authentication.js
+++ b/server/modules/authentication/oidc/authentication.js
@@ -29,7 +29,7 @@ module.exports = {
             profile: {
               ...profile,
               email: _.get(profile, '_json.' + conf.emailClaim),
-              displayName: _.get(profile, conf.displayNameClaim, '???'),
+              displayName: _.get(profile, conf.displayNameClaim, ''),
             }
           })
           if (conf.mapGroups) {

--- a/server/modules/authentication/oidc/authentication.js
+++ b/server/modules/authentication/oidc/authentication.js
@@ -28,7 +28,8 @@ module.exports = {
             providerKey: req.params.strategy,
             profile: {
               ...profile,
-              email: _.get(profile, '_json.' + conf.emailClaim)
+              email: _.get(profile, '_json.' + conf.emailClaim),
+              displayName: _.get(profile, conf.displayNameClaim, '???'),
             }
           })
           if (conf.mapGroups) {

--- a/server/modules/authentication/oidc/definition.yml
+++ b/server/modules/authentication/oidc/definition.yml
@@ -51,8 +51,8 @@ props:
     order: 7
   displayNameClaim:
     type: String
-    title: DisplayName Claim
-    hint: Field containing the users display name
+    title: Display Name Claim
+    hint: Field containing the user display name
     default: displayName
     maxWidth: 500
     order: 8

--- a/server/modules/authentication/oidc/definition.yml
+++ b/server/modules/authentication/oidc/definition.yml
@@ -49,21 +49,28 @@ props:
     default: email
     maxWidth: 500
     order: 7
+  displayNameClaim:
+    type: String
+    title: DisplayName Claim
+    hint: Field containing the users display name
+    default: displayName
+    maxWidth: 500
+    order: 8
   mapGroups:
     type: Boolean
     title: Map Groups
     hint: Map groups matching names from the groups claim value
     default: false
-    order: 8
+    order: 9
   groupsClaim:
     type: String
     title: Groups Claim
     hint: Field containing the group names
     default: groups
     maxWidth: 500
-    order: 9
+    order: 10
   logoutURL:
     type: String
     title: Logout URL
     hint: (optional) Logout URL on the OAuth2 provider where the user will be redirected to complete the logout process.
-    order: 10
+    order: 11


### PR DESCRIPTION
I noticed when setting up the oidc authentication method, that it just uses the first part of the email (for my oidc provider authentik). In parallel to the oauth module I added the option to change the claim for the displayName so it can be set manually.