### PR TITLE
Enable state key on generic oauth2

### DIFF
--- a/server/modules/authentication/oauth2/authentication.js
+++ b/server/modules/authentication/oauth2/authentication.js
@@ -18,7 +18,8 @@ module.exports = {
       userInfoURL: conf.userInfoURL,
       callbackURL: conf.callbackURL,
       passReqToCallback: true,
-      scope: conf.scope
+      scope: conf.scope,
+      state: true
     }, async (req, accessToken, refreshToken, profile, cb) => {
       try {
         const user = await WIKI.models.users.processProfile({


### PR DESCRIPTION
This PR enables the state key on the generic oauth2 requests. The state key is more secure and is required by a lot of oauth2 providers such as Authelia. https://www.rfc-editor.org/rfc/rfc6819#section-4.4.1.8

A working config for Authelia. (What I used to test this patch)
```yaml
- id: Wikijs # this should be changed to something more secure
  description: Wikijs SSO
  secret: '' # Long randomly generated string
  public: false
  authorization_policy: one_factor
  audience: []
  scopes:
    - openid
    - profile
    - email
  redirect_uris:
    - https://wiki.example.com/login/{UNIQUE_ID}/callback # Copy this from the bottom of the oauth2 setup in wikijs
  userinfo_signing_algorithm: none
  grant_types:
    - authorization_code
```

![Screenshot_20230129_161432-1](https://user-images.githubusercontent.com/34520077/215356223-96abfc8c-77c3-4821-b20c-dcc17d1a6dd2.png)

If you are using Authelia's file database
```yaml
user:
  disabled: false
  displayname: "User"
  display_name: "User"
  password: ""
  email: user@example.com
  groups:
    - owner
    - user
```