### PR TITLE
fix: code style in blockquote

### DIFF
--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -282,7 +282,7 @@
         content: "\F02FC";
       }
 
-      code {
+      code:not([class^="language-"]) {
         background-color: mc('blue', '50');
         color: mc('blue', '800');
       }
@@ -302,7 +302,7 @@
         content: "\F0026";
       }
 
-      code {
+      code:not([class^="language-"]) {
         background-color: mc('orange', '50');
         color: mc('orange', '800');
       }
@@ -323,7 +323,7 @@
         content: "\F0159";
       }
 
-      code {
+      code:not([class^="language-"]) {
         background-color: mc('red', '50');
         color: mc('red', '800');
       }
@@ -343,7 +343,7 @@
         content: "\F0E1E";
       }
 
-      code {
+      code:not([class^="language-"]) {
         background-color: mc('green', '50');
         color: mc('green', '800');
       }


### PR DESCRIPTION
To follow up on PR #5895, and discussion #5894, I propose this little modification to not impact the inline code.

The goal is to apply the style only if `code` doesn't have a class whose name starts with "language-" which is the case as soon as you use a code block. Inline code does not use a language-* class.

Sorry for my English.