### PR TITLE
fix: import error on date title

### DIFF
--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -199,7 +199,10 @@ module.exports = class Page extends Model {
           result = frontmatterRegex.markdown.exec(raw)
           if (result[2]) {
             return {
-              ...yaml.safeLoad(result[2]),
+              ...yaml.safeLoad(result[2], {
+                json: true,
+                schema: yaml.CORE_SCHEMA
+              }),
               content: result[3]
             }
           } else {


### PR DESCRIPTION
When I try to import markdown with date format title, the parsing fail. `js-yaml` will always convert the title into the date format. The caveat  of this approach is the `create_date` and `update_date` will also become string. However, since we are not importing that, it doesn't seem to be an issue for importing.

An alternative approach is to make sure title is a string. However, I don't want my `2023-01-01` turn to a long formatted date.

You can see this by pasting the code below https://nodeca.github.io/js-yaml/
```yaml
---
title: 2023-01-01
```