### PR TITLE
feat: include query parameters in locale redirect

### DIFF
--- a/server/controllers/common.js
+++ b/server/controllers/common.js
@@ -4,6 +4,7 @@ const pageHelper = require('../helpers/page')
 const _ = require('lodash')
 const CleanCSS = require('clean-css')
 const moment = require('moment')
+const qs = require('querystring')
 
 /* global WIKI */
 
@@ -420,7 +421,8 @@ router.get('/*', async (req, res, next) => {
 
   if (isPage) {
     if (WIKI.config.lang.namespacing && !pageArgs.explicitLocale) {
-      return res.redirect(`/${pageArgs.locale}/${pageArgs.path}`)
+      let query = (!_.isEmpty(req.query)) ? `?${qs.stringify(req.query)}` : ``
+      return res.redirect(`/${pageArgs.locale}/${pageArgs.path}${query}`)
     }
 
     req.i18n.changeLanguage(pageArgs.locale)

--- a/server/controllers/common.js
+++ b/server/controllers/common.js
@@ -421,7 +421,7 @@ router.get('/*', async (req, res, next) => {
 
   if (isPage) {
     if (WIKI.config.lang.namespacing && !pageArgs.explicitLocale) {
-      let query = (!_.isEmpty(req.query)) ? `?${qs.stringify(req.query)}` : ``
+      const query = !_.isEmpty(req.query) ? `?${qs.stringify(req.query)}` : ''
       return res.redirect(`/${pageArgs.locale}/${pageArgs.path}${query}`)
     }
 


### PR DESCRIPTION
When requesting a page without an explicit locale, the server will redirect to a locale specific page. However, the redirect drops the query parameters on the original request. It would be nice to retain the query parameters. We have a page that has some JS to further redirect someone to a more specific page. Currently this only works when the original request goes to a page with an explicit locale.