### PR TITLE
Try updating to the new location and current version for root's acme

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@root/csr": "0.8.1",
     "@root/keypairs": "0.10.3",
     "@root/pem": "1.0.4",
-    "acme": "3.0.3",
+    "@root/acme": "3.1.0",
     "akismet-api": "5.3.0",
     "algoliasearch": "4.5.1",
     "apollo-fetch": "0.7.0",

--- a/server/core/letsencrypt.js
+++ b/server/core/letsencrypt.js
@@ -1,4 +1,4 @@
-const ACME = require('acme')
+const ACME = require('@root/acme')
 const Keypairs = require('@root/keypairs')
 const _ = require('lodash')
 const moment = require('moment')


### PR DESCRIPTION
I ran into https://github.com/requarks/wiki/discussions/3459#discussioncomment-3189144 when trying to set up SSL terminated directly by wiki.js on DigitalOcean, and I noticed it was running into trouble in some code in the `acme` module that has been changed for a bugfix since about the 3.0.3 we are using, but which hasn't been picked up because the module moved in NPM. It now lives in `@root` with a bunch of the other related modules, and the current version is 3.1.0.

This is an attempt to move to that version of the module, to maybe resolve my weird LetsEncrypt issues. If this doesn't pass tests, there are other 3.0.x patch releases under `@root` we could try.

I'm not sure this will really fix the bug though; the commit I think I need:

https://github.com/therootcompany/acme.js/commit/0aa939a22788ea82303e739226ad5ea196c042cc

is only in 3.1.1, not 3.1.0. And 3.1.1 is released on Github but never got published in NPM; see https://github.com/therootcompany/acme.js/issues/4

Nonetheless, I don't think it makes sense to keep using the *old* module name.

I tried to `npm install` to get any lockfiles to update, but it did not appear to make any changes to tracked files. I also tried to `npm run test` to make sure this actually works, and I got a bunch of error-level messages from the linter that had nothing to do with my change, like:

```
error: Custom event name 'resetEditorConflict' must be kebab-case (vue/custom-event-name-casing) at client/components/editor/ckeditor/conflict.vue:86:24:
  84 |     useLocal () {
  85 |       this.$store.set('editor/checkoutDateActive', this.latest.updatedAt)
> 86 |       this.$root.$emit('resetEditorConflict')
     |                        ^
  87 |       this.close()
  88 |     },
  89 |     useRemote () {
```

I think I'm not setting up the project for development in the same way as other contributors are, but there's nothing in the README or contributing file that suggests that I should be doing anything different. So hopefully CI can test this and no lockfile changes are needed.