### PR TITLE
[Suggestion] Slight increase of indentation in lists

### DIFF
--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -513,7 +513,7 @@
 
     li > ul, li > ol {
       padding-top: .5rem;
-      padding-left: 1rem;
+      padding-left: 2rem;
 
       @at-root .is-rtl & {
         padding-left: 0;


### PR DESCRIPTION
It seems to me that the indentation of the lists is a bit weak to easily identify the sub-elements.

I propose this commit to slightly increase the padding-left to 2rem instead of 1rem.

- With 1 rem : 

![](https://i.imgur.com/U06HQRA.png)

- With 2 rem : 

![](https://i.imgur.com/9rGcZxv.png)