### PR TITLE
Fix "Invalid branch!" because of color.branch

### DIFF
--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -48,7 +48,7 @@ module.exports = {
     // Disable quotePath, color output
     // Link https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath
     await this.git.raw(['config', '--local', 'core.quotepath', false])
-    await this.git.raw(['config', '--local', 'color.ui', false])
+    await this.git.raw(['config', '--local', 'color.branch', false])
 
     // Set default author
     await this.git.raw(['config', '--local', 'user.email', this.config.defaultEmail])


### PR DESCRIPTION
Following discussion #6112 and PR #6014, it seems that setting `color.ui` to false is not enough. Removing `color.ui` and replacing it with `color.branch` fixes my problem.

I recreated the configuration from scratch and the `/.git/config` contains the right values:

```gitconfig
[color]
    branch = false
```

and there is no more error on the interpretation of the branch name.