### PR TITLE
Add skipUserProfile option for Generic OpenID Connect / OAuth2 Authentication

### DIFF
--- a/server/modules/authentication/oidc/authentication.js
+++ b/server/modules/authentication/oidc/authentication.js
@@ -19,7 +19,8 @@ module.exports = {
         issuer: conf.issuer,
         userInfoURL: conf.userInfoURL,
         callbackURL: conf.callbackURL,
-        passReqToCallback: true
+        passReqToCallback: true,
+        skipUserProfile: conf.skipUserProfile
       }, async (req, iss, uiProfile, idProfile, context, idToken, accessToken, refreshToken, params, cb) => {
         const profile = Object.assign({}, idProfile, uiProfile)
 

--- a/server/modules/authentication/oidc/definition.yml
+++ b/server/modules/authentication/oidc/definition.yml
@@ -37,40 +37,46 @@ props:
     title: User Info Endpoint URL
     hint: User Info Endpoint URL
     order: 5
+  skipUserProfile:
+    type: Boolean
+    default: false
+    title: Skip User Profile
+    hint: Skips call to the OIDC UserInfo endpoint
+    order: 6
   issuer:
     type: String
     title: Issuer
     hint: Issuer URL
-    order: 6
+    order: 7
   emailClaim:
     type: String
     title: Email Claim
     hint: Field containing the email address
     default: email
     maxWidth: 500
-    order: 7
+    order: 8
   displayNameClaim:
     type: String
     title: Display Name Claim
     hint: Field containing the user display name
     default: displayName
     maxWidth: 500
-    order: 8
+    order: 9
   mapGroups:
     type: Boolean
     title: Map Groups
     hint: Map groups matching names from the groups claim value
     default: false
-    order: 9
+    order: 10
   groupsClaim:
     type: String
     title: Groups Claim
     hint: Field containing the group names
     default: groups
     maxWidth: 500
-    order: 10
+    order: 11
   logoutURL:
     type: String
     title: Logout URL
     hint: (optional) Logout URL on the OAuth2 provider where the user will be redirected to complete the logout process.
-    order: 11
+    order: 12


### PR DESCRIPTION
This pull request adds a new option "skip user profile" to the settings for the Generic OpenID Connect / Oauth2 authentication. The default is false. This exposes the option to skipUserProfile which is configurable in the underlying library that WikiJS uses: passport-openidconnect

The advantage of having this option is so that we can integrate with CIAM (customer identity access management) solutions such as Azure AD B2C which do NOT have the UserInfo endpoint as default.

Furthermore, it seems that WikiJS does not actually use the UserInfo endpoint for anything, as the Display name is taken from the email claim.

The change has been tested with Azure AD B2C and works well. NOTE: A custom policy is still required on this platform in order to return the "email" claim!