### PR TITLE
feat(helm): allow usage of additional env vars / configmap / secrets

### DIFF
--- a/dev/helm/Chart.yaml
+++ b/dev/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: wiki
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.2.0
+version: 2.3.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
 AppVersion: latest

--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ default "latest" .Values.image.tag }}"
           imagePullPolicy: {{ default "IfNotPresent" .Values.image.imagePullPolicy }}
           env:
+            {{- with .Values.extraEnv.env }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
             - name: DB_TYPE
               value: postgres
             {{- if (.Values.externalPostgresql).databaseURL }}
@@ -46,7 +49,8 @@ spec:
               value: {{ .Values.externalPostgresql.databaseURL }}
             - name: NODE_TLS_REJECT_UNAUTHORIZED
               value: {{ default "1" .Values.externalPostgresql.NODE_TLS_REJECT_UNAUTHORIZED | quote }}
-            {{- else }}
+            {{- end }}
+            {{- if .Values.postgresql.enabled}}
             - name: DB_HOST
               value: {{ template "wiki.postgresql.host" . }}
             - name: DB_PORT
@@ -71,6 +75,19 @@ spec:
             {{- end }}
             - name: HA_ACTIVE
               value: {{ .Values.replicaCount | int | le 2 | quote }}
+          envFrom:
+            {{- with .Values.extraEnv.configmaps }}
+              {{- range $v := . }}
+            - configMapRef:
+                name: {{ $v }}
+              {{- end }}
+            {{- end }}
+            {{- with .Values.extraEnv.secrets }}
+              {{- range $v := . }}
+            - secretRef:
+                name: {{ $v }}
+              {{- end }}
+            {{- end }}
     {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
             - name: HA_ACTIVE
               value: {{ .Values.replicaCount | int | le 2 | quote }}
           envFrom:
-            {{- with .Values.extraEnv.configmaps }}
+            {{- with .Values.extraEnv.configMaps }}
               {{- range $v := . }}
             - configMapRef:
                 name: {{ $v }}

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -98,6 +98,22 @@ tolerations: []
 
 affinity: {}
 
+extraEnv:
+  env: []
+#    - name: SAMPLE_ENV
+#      value: "sample value"
+#    - name: SAMPLE_ENV_FROM_SECRET
+#      valueFrom:
+#        secretKeyRef:
+#          name: 'secret-name'
+#          key: 'secret-key'
+  secrets: []
+#    - secret-name
+#    - another-secret-name
+  configmaps: []
+#    - configmap-name
+#    - another-configmap-name
+
 volumeMounts: []
 
 volumes: []

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -110,7 +110,7 @@ extraEnv:
   secrets: []
 #    - secret-name
 #    - another-secret-name
-  configmaps: []
+  configMaps: []
 #    - configmap-name
 #    - another-configmap-name
 


### PR DESCRIPTION
This PR makes it possible to load external environmenent variables.
On my cluster, I'm using [Postgres Operator](https://access.crunchydata.com/documentation/postgres-operator/latest/) by CrunchyData, I need to be able to load the generated database secrets directly rather than copying it in the values.