### PR TITLE
Allows setting the NODE_EXTRA_CA_CERTS variable

### DIFF
--- a/dev/helm/README.md
+++ b/dev/helm/README.md
@@ -115,6 +115,7 @@ The following table lists the configurable parameters of the Wiki.js chart and t
 | `sideload.enabled`                   | Enable sideloading of locale files from git | `false`                                                    |
 | `sideload.repoURL`                   | Git repository URL containing locale files  | `https://github.com/Requarks/wiki-localization`            |
 | `sideload.env`                       | Environment variables for sideload Container | `{}`                                                      |
+| `NODE_EXTRA_CA_CERTS`                | Trusted certificates path                   | `nil`                                                      |
 | `postgresql.enabled`                 | Deploy postgres server (see below)          | `true`                                                     |
 | `postgresql.postgresqlDatabase`        | Postgres database name                      | `wiki`                                                   |
 | `postgresql.postgresqlUser`            | Postgres username                           | `postgres`                                                   |
@@ -145,6 +146,39 @@ $ helm install --name my-release -f values.yaml requarks/wiki
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
+
+## Append extra trusted certificates
+
+1. Create ConfigMap with CAs in PEM format.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ca
+  namespace: your-wikijs-namespace
+data:
+  certs.pem: |-
+    -----BEGIN CERTIFICATE-----
+    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    -----END CERTIFICATE-----
+```
+
+2. Mount your CAs from ConfigMap to WikiJS pod and set `NODE_EXTRA_CA_CERTS` variable. Insert the following lines to your WikiJS values.yaml.
+
+```yaml
+volumeMounts:
+  - name: ca
+    mountPath: /cas.pem
+    subPath: certs.pem
+
+volumes:
+  - name: ca
+    configMap:
+      name: ca
+
+NODE_EXTRA_CA_CERTS: "/cas.pem"
+```
 
 ## PostgresSQL
 

--- a/dev/helm/README.md
+++ b/dev/helm/README.md
@@ -147,39 +147,6 @@ $ helm install --name my-release -f values.yaml requarks/wiki
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
 
-## Append extra trusted certificates
-
-1. Create ConfigMap with CAs in PEM format.
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: ca
-  namespace: your-wikijs-namespace
-data:
-  certs.pem: |-
-    -----BEGIN CERTIFICATE-----
-    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-    -----END CERTIFICATE-----
-```
-
-2. Mount your CAs from ConfigMap to WikiJS pod and set `nodeExtraCaCerts` helm variable. Insert the following lines to your WikiJS values.yaml.
-
-```yaml
-volumeMounts:
-  - name: ca
-    mountPath: /cas.pem
-    subPath: certs.pem
-
-volumes:
-  - name: ca
-    configMap:
-      name: ca
-
-nodeExtraCaCerts: "/cas.pem"
-```
-
 ## PostgresSQL
 
 By default, PostgreSQL is installed as part of the chart.
@@ -209,3 +176,38 @@ See the [Configuration](#configuration) section to configure the PVC or to disab
 ## Ingress
 
 This chart provides support for Ingress resource. If you have an available Ingress Controller such as Nginx or Traefik you maybe want to set `ingress.enabled` to true and add `ingress.hosts` for the URL. Then, you should be able to access the installation using that address.
+
+## Extra Trusted Certificates
+
+To append extra CA Certificates:
+
+1. Create a ConfigMap with CAs in PEM format, e.g.:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ca
+  namespace: your-wikijs-namespace
+data:
+  certs.pem: |-
+    -----BEGIN CERTIFICATE-----
+    XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    -----END CERTIFICATE-----
+```
+
+2. Mount your CAs from the ConfigMap to the Wiki.js pod and set `nodeExtraCaCerts` helm variable. Insert the following lines to your Wiki.js `values.yaml`, e.g.:
+
+```yaml
+volumeMounts:
+  - name: ca
+    mountPath: /cas.pem
+    subPath: certs.pem
+
+volumes:
+  - name: ca
+    configMap:
+      name: ca
+
+nodeExtraCaCerts: "/cas.pem"
+```

--- a/dev/helm/README.md
+++ b/dev/helm/README.md
@@ -115,7 +115,7 @@ The following table lists the configurable parameters of the Wiki.js chart and t
 | `sideload.enabled`                   | Enable sideloading of locale files from git | `false`                                                    |
 | `sideload.repoURL`                   | Git repository URL containing locale files  | `https://github.com/Requarks/wiki-localization`            |
 | `sideload.env`                       | Environment variables for sideload Container | `{}`                                                      |
-| `NODE_EXTRA_CA_CERTS`                | Trusted certificates path                   | `nil`                                                      |
+| `nodeExtraCaCerts`                   | Trusted certificates path                   | `nil`                                                      |
 | `postgresql.enabled`                 | Deploy postgres server (see below)          | `true`                                                     |
 | `postgresql.postgresqlDatabase`        | Postgres database name                      | `wiki`                                                   |
 | `postgresql.postgresqlUser`            | Postgres username                           | `postgres`                                                   |
@@ -164,7 +164,7 @@ data:
     -----END CERTIFICATE-----
 ```
 
-2. Mount your CAs from ConfigMap to WikiJS pod and set `NODE_EXTRA_CA_CERTS` variable. Insert the following lines to your WikiJS values.yaml.
+2. Mount your CAs from ConfigMap to WikiJS pod and set `nodeExtraCaCerts` helm variable. Insert the following lines to your WikiJS values.yaml.
 
 ```yaml
 volumeMounts:
@@ -177,7 +177,7 @@ volumes:
     configMap:
       name: ca
 
-NODE_EXTRA_CA_CERTS: "/cas.pem"
+nodeExtraCaCerts: "/cas.pem"
 ```
 
 ## PostgresSQL

--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ default "latest" .Values.image.tag }}"
           imagePullPolicy: {{ default "IfNotPresent" .Values.image.imagePullPolicy }}
           env:
+            {{- if .Values.NODE_EXTRA_CA_CERTS }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: {{ .Values.NODE_EXTRA_CA_CERTS }}
+            {{- end }}
             - name: DB_TYPE
               value: postgres
             {{- if (.Values.externalPostgresql).databaseURL }}

--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -39,9 +39,9 @@ spec:
           image: "{{ .Values.image.repository }}:{{ default "latest" .Values.image.tag }}"
           imagePullPolicy: {{ default "IfNotPresent" .Values.image.imagePullPolicy }}
           env:
-            {{- if .Values.NODE_EXTRA_CA_CERTS }}
+            {{- if .Values.nodeExtraCaCerts }}
             - name: NODE_EXTRA_CA_CERTS
-              value: {{ .Values.NODE_EXTRA_CA_CERTS }}
+              value: {{ .Values.nodeExtraCaCerts }}
             {{- end }}
             - name: DB_TYPE
               value: postgres

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -113,8 +113,8 @@ sideload:
   #  - name: HTTPS_PROXY
   #    value: http://my.proxy.com:3128
 
-# Append extra trusted certificates for node process from extra volume
-#NODE_EXTRA_CA_CERTS: "/path/to/certs.pem"
+# Append extra trusted certificates for node process from extra volume via NODE_EXTRA_CA_CERTS variable
+#nodeExtraCaCerts: "/path/to/certs.pem"
 
 ## This will override the postgresql chart values
 # externalPostgresql:

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -91,7 +91,6 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
-
 nodeSelector: {}
 
 tolerations: []
@@ -112,6 +111,9 @@ sideload:
   env: []
   #  - name: HTTPS_PROXY
   #    value: http://my.proxy.com:3128
+
+# Append extra trusted certificates for node process from extra volume
+#NODE_EXTRA_CA_CERTS: "/path/to/certs.pem"
 
 ## This will override the postgresql chart values
 # externalPostgresql:

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -113,8 +113,8 @@ sideload:
   #  - name: HTTPS_PROXY
   #    value: http://my.proxy.com:3128
 
-# Append extra trusted certificates for node process from extra volume via NODE_EXTRA_CA_CERTS variable
-#nodeExtraCaCerts: "/path/to/certs.pem"
+## Append extra trusted certificates for node process from extra volume via NODE_EXTRA_CA_CERTS variable
+# nodeExtraCaCerts: "/path/to/certs.pem"
 
 ## This will override the postgresql chart values
 # externalPostgresql:

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -91,6 +91,7 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
We have the keycloak instance signed with our internal CA and I do not like disabling of certs trusting. So we just need to append extra CA certs.