### PR TITLE
Elasticsearch hits# fix

### DIFF
--- a/server/modules/search/elasticsearch/engine.js
+++ b/server/modules/search/elasticsearch/engine.js
@@ -137,7 +137,7 @@ module.exports = {
           description: r._source.description
         })),
         suggestions: _.reject(_.get(results, 'suggest.suggestions', []).map(s => _.get(s, 'options[0].text', false)), s => !s),
-        totalHits: _.get(results, 'body.hits.total.value', _.get(results, 'body.hits.total', 0))
+        totalHits: _.get(results, 'body.hits.hits', []).map(r => r.length)
       }
     } catch (err) {
       WIKI.logger.warn('Search Engine Error: ', _.get(err, 'meta.body.error', err))


### PR DESCRIPTION
Elasticsearch may provide wrong total hits number, which may cause in the frontend generating too many paginations and results with no references.
Counting the length of the returned results from Elasticsearch may solve the problem.