### PR TITLE
[Fix] List paragraphs inline 100%, image into lists

### DIFF
--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -685,6 +685,7 @@
         display:inline-block;
         vertical-align:top;
         padding-top:0;
+	width: 100%;
       }
     }
   }

--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -685,7 +685,9 @@
         display:inline-block;
         vertical-align:top;
         padding-top:0;
-	width: 100%;
+	&:first-child {
+		width: 100%;
+	}
       }
     }
   }

--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -685,9 +685,10 @@
         display:inline-block;
         vertical-align:top;
         padding-top:0;
-	&:first-child {
-		width: 100%;
-	}
+        
+        &:first-child {
+          width: 100%;
+        }
       }
     }
   }


### PR DESCRIPTION
Hello. 

Editing in a private wiki, I try to use images to be part of a list, the issue is that those got aligned with the text, so I tested with the css to fix it. I also thought to change it with `display:block;`, but if there's a reason to use inline-block for this, this change still will respect that and fix this issue. I include this tests images.

Before:
![Captura de pantalla-20230317151347-784x340](https://user-images.githubusercontent.com/38993394/226057227-2f7e27b2-0443-4557-bd78-b47fa4f25482.png)

After:
![Captura de pantalla-20230317151307-908x422](https://user-images.githubusercontent.com/38993394/226057252-0cfa4da8-5388-4b04-a713-b287c7b1b41c.png)
