### PR TITLE
Clearify OIDC Group Mapping

### DIFF
--- a/server/modules/authentication/oidc/definition.yml
+++ b/server/modules/authentication/oidc/definition.yml
@@ -65,7 +65,7 @@ props:
   mapGroups:
     type: Boolean
     title: Map Groups
-    hint: Map groups matching names from the groups claim value
+    hint: Map groups (except System Groups) matching names from the groups claim value
     default: false
     order: 10
   groupsClaim:


### PR DESCRIPTION
When I set up an OIDC connection, I was wondering if, for example, the "Administrators" group membership is also picked up by the Authenticator. This does not seem to be the case, so I made an adjustment to the note to make this clear in the settings.