### PR TITLE
Updated discord authentication to allow for optional filtering by discord server role

### DIFF
--- a/server/helpers/error.js
+++ b/server/helpers/error.js
@@ -73,6 +73,10 @@ module.exports = {
     message: 'You are not authorized to register. Your domain is not whitelisted.',
     code: 1011
   }),
+   AuthDiscordRoleUnauthorized: CustomError('AuthDiscordRoleUnauthorized', {
+    message: 'You are not authorized to register. You lack the necessary Server Roles.',
+    code: 1012
+  }),
   AuthRequired: CustomError('AuthRequired', {
     message: 'You must be authenticated to access this resource.',
     code: 1019

--- a/server/modules/authentication/discord/definition.yml
+++ b/server/modules/authentication/discord/definition.yml
@@ -23,3 +23,8 @@ props:
     title: Server ID
     hint: Optional - Your unique server identifier, such that only members are authorized
     order: 3
+  roles:
+    type: String
+    title: Required Roles
+    hint: Optional - Comma-separated list of server role IDs that are required for access (you must hae a Server ID configured to use this.)
+    order: 4


### PR DESCRIPTION
I modified the authentication.js to allow the admin to set a comma-separated list of role IDs in the authentication configure. If that value is set, then the authentication process will check the configured roles against the user's roles on the discord server. If they have all of the required roles then it will allow them to sign in.