### PR TITLE
Always redirect to login provider when autoLogin is set

### DIFF
--- a/server/controllers/common.js
+++ b/server/controllers/common.js
@@ -450,6 +450,9 @@ router.get('/*', async (req, res, next) => {
         if (pageArgs.path === 'home' && req.user.id === 2) {
           return res.redirect('/login')
         }
+        if (WIKI.config.auth.autoLogin && req.user.id === 2) {
+          return res.redirect('/login')
+        }
         _.set(res.locals, 'pageMeta.title', 'Unauthorized')
         return res.status(403).render('unauthorized', {
           action: 'view'


### PR DESCRIPTION
When the administrator has chosen to bypass the login screen, this change will take an unauthorized guest user to the login provider for _any_ link, not just the home page.  This should provide a solution for several feedback items, such as:

https://feedback.js.wiki/wiki/p/bypass-login-screen-option-should-apply-to-deep-links (mine! 😄)
https://feedback.js.wiki/wiki/p/login-auto-redirect
https://feedback.js.wiki/wiki/p/skip-unauthorized-screen-for-private-wikis

Steps to recreate (in a dev instance):
1. Create a `/subpage` as a secondary page (in addition to the homepage)
1. Remove all read access to guests in the admin section
1. Choose "Bypass Login Screen" in the Security area of the admin section
1. Log out (or open a private browsing window)
1. Navigate directly to the newly created `/subpage` -- it should send you to the login screen instead of returning an 'Unauthorized' error.

If there's a different way you'd prefer this implemented, I'm happy to help!