### PR TITLE
Allow custom GitLab endpoints for self-hosting

### DIFF
--- a/server/modules/authentication/gitlab/authentication.js
+++ b/server/modules/authentication/gitlab/authentication.js
@@ -15,6 +15,8 @@ module.exports = {
         clientSecret: conf.clientSecret,
         callbackURL: conf.callbackURL,
         baseURL: conf.baseUrl,
+        authorizationURL: conf.authorizationURL || conf.baseUrl + '/oauth/authorize',
+        tokenURL: conf.tokenURL || conf.baseUrl + '/oauth/token',
         scope: ['read_user'],
         passReqToCallback: true
       }, async (req, accessToken, refreshToken, profile, cb) => {

--- a/server/modules/authentication/gitlab/authentication.js
+++ b/server/modules/authentication/gitlab/authentication.js
@@ -15,8 +15,8 @@ module.exports = {
         clientSecret: conf.clientSecret,
         callbackURL: conf.callbackURL,
         baseURL: conf.baseUrl,
-        authorizationURL: conf.authorizationURL || conf.baseUrl + '/oauth/authorize',
-        tokenURL: conf.tokenURL || conf.baseUrl + '/oauth/token',
+        authorizationURL: conf.authorizationURL || (conf.baseUrl + '/oauth/authorize'),
+        tokenURL: conf.tokenURL || (conf.baseUrl + '/oauth/token'),
         scope: ['read_user'],
         passReqToCallback: true
       }, async (req, accessToken, refreshToken, profile, cb) => {

--- a/server/modules/authentication/gitlab/definition.yml
+++ b/server/modules/authentication/gitlab/definition.yml
@@ -27,10 +27,10 @@ props:
   authorizationURL:
     type: String
     title: Authorization URL
-    hint: For self-managed GitLab instances, define an alternate authorization URL (e.g. http://172.28.0.5:8929/oauth/authorize). Leave default to generate from baseUrl.
+    hint: For self-managed GitLab instances, define an alternate authorization URL (e.g. http://example.com/oauth/authorize). Leave empty otherwise.
     order: 4
   tokenURL:
     type: String
     title: Token URL
-    hint: For self-managed GitLab instances, define an alternate token URL (e.g. http://172.28.0.5:8929/oauth/token). Leave default to generate from baseUrl.
+    hint: For self-managed GitLab instances, define an alternate token URL (e.g. http://example.com/oauth/token). Leave empty otherwise.
     order: 5

--- a/server/modules/authentication/gitlab/definition.yml
+++ b/server/modules/authentication/gitlab/definition.yml
@@ -24,3 +24,13 @@ props:
     hint: For self-managed GitLab instances, define the base URL (e.g. https://gitlab.example.com). Leave default for GitLab.com SaaS (https://gitlab.com).
     default: https://gitlab.com
     order: 3
+  authorizationURL:
+    type: String
+    title: Authorization URL
+    hint: For self-managed GitLab instances, define an alternate authorization URL (e.g. http://172.28.0.5:8929/oauth/authorize). Leave default to generate from baseUrl.
+    order: 4
+  tokenURL:
+    type: String
+    title: Token URL
+    hint: For self-managed GitLab instances, define an alternate token URL (e.g. http://172.28.0.5:8929/oauth/token). Leave default to generate from baseUrl.
+    order: 5


### PR DESCRIPTION
In some setups, self-hosting GitLab will require a different auth or tokenUrl than the baseUrl used to redirect the user to approve access. For example, there may be a firewall blocking WikiJS from accessing GitLab on the same server using the public baseUrl. This is the root of the problem I was facing here: https://github.com/requarks/wiki/discussions/6377 .

This PR adds `authorizationURL` and `tokenURL` as configuration options for the GitLab authentication strategy. This allows the baseUrl to be set to redirect the user for approval, but have WikiJS use an internal tokenURL for validation. These new options may be left empty and they will be calculated from baseUrl the way they currently are. This is a non-breaking change.