### PR TITLE
feat: update title of analytics module umami

### DIFF
--- a/server/modules/analytics/umami/definition.yml
+++ b/server/modules/analytics/umami/definition.yml
@@ -1,5 +1,5 @@
 key: umami
-title: Umami Analytics V1
+title: Umami Analytics v1
 description: Umami is a simple, fast, privacy-focused alternative to Google Analytics.
 author: CDN18
 logo: https://static.requarks.io/logo/umami.svg

--- a/server/modules/analytics/umami/definition.yml
+++ b/server/modules/analytics/umami/definition.yml
@@ -1,5 +1,5 @@
 key: umami
-title: Umami Analytics
+title: Umami Analytics V1
 description: Umami is a simple, fast, privacy-focused alternative to Google Analytics.
 author: CDN18
 logo: https://static.requarks.io/logo/umami.svg

--- a/server/modules/analytics/umami2/code.yml
+++ b/server/modules/analytics/umami2/code.yml
@@ -1,0 +1,2 @@
+head: |
+  <script async src="{{url}}/script.js" data-website-id="{{websiteID}}"></script>

--- a/server/modules/analytics/umami2/definition.yml
+++ b/server/modules/analytics/umami2/definition.yml
@@ -1,5 +1,5 @@
 key: umami2
-title: Umami Analytics V2
+title: Umami Analytics v2
 description: Umami is a simple, fast, privacy-focused alternative to Google Analytics.
 author: CDN18
 logo: https://static.requarks.io/logo/umami.svg

--- a/server/modules/analytics/umami2/definition.yml
+++ b/server/modules/analytics/umami2/definition.yml
@@ -1,0 +1,17 @@
+key: umami2
+title: Umami Analytics V2
+description: Umami is a simple, fast, privacy-focused alternative to Google Analytics.
+author: CDN18
+logo: https://static.requarks.io/logo/umami.svg
+website: https://umami.is
+isAvailable: true
+props:
+  websiteID:
+    type: String
+    title: Website ID
+    order: 1
+  url:
+    type: String
+    title: Umami Server URL
+    hint: The URL of your Umami instance. It should start with http/https and omit the trailing slash. (e.g. https://umami.example.com)
+    order: 2


### PR DESCRIPTION
According to the discussion results of [PR#6412](https://github.com/requarks/wiki/pull/6412), I have created a module with ID `umami2` in this PR to adapt to the breaking changes of Umami, and accordingly updated the name of the original Umami module.