### PR TITLE
Remove duplicate query parameters on HTTPS redirect

### DIFF
--- a/server/controllers/ssl.js
+++ b/server/controllers/ssl.js
@@ -28,8 +28,7 @@ router.get('/.well-known/acme-challenge/:token', (req, res, next) => {
  */
 router.all('/*', (req, res, next) => {
   if (WIKI.config.server.sslRedir && !req.secure && WIKI.servers.servers.https) {
-    let query = (!_.isEmpty(req.query)) ? `?${qs.stringify(req.query)}` : ``
-    return res.redirect(`https://${req.hostname}${req.originalUrl}${query}`)
+    return res.redirect(`https://${req.hostname}${req.originalUrl}`)
   } else {
     next()
   }


### PR DESCRIPTION
HTTPS redirection rebuilds the full URL using `req.originalUrl`, which includes query parameters (see the
[express docs](https://expressjs.com/en/api.html#req.originalUrl)). Prior to this patch, appending the stringified query params to `req.originalUrl` resulted in duplicate parameters, e.g.
`wiki.js/callback?session=123&code=abc?session=123&code=abc`
which caused errors when being redirected from an insecure (http://) callback URL to a secure version when using Keycloak auth.

This issue is probably rare, but in cases where HTTPS redirection is enabled and a user tries to hit an insecure URL with query parameters, it could cause problems.

