### PR TITLE
fix(git): Reduce concurrency to avoid lock file conflicts.

### DIFF
--- a/server/modules/storage/git/storage.js
+++ b/server/modules/storage/git/storage.js
@@ -30,7 +30,7 @@ module.exports = {
     WIKI.logger.info('(STORAGE/GIT) Initializing...')
     this.repoPath = path.resolve(WIKI.ROOTPATH, this.config.localRepoPath)
     await fs.ensureDir(this.repoPath)
-    this.git = sgit(this.repoPath)
+    this.git = sgit(this.repoPath, { maxConcurrentProcesses: 1 })
 
     // Set custom binary path
     if (!_.isEmpty(this.config.gitBinaryPath)) {


### PR DESCRIPTION
This PR should resolve #5074 (or at the very list make the likelyhood of it occurring much less).

The underlying simple-git library defaults maxConcurrentProcesses to 5. This creates problems when multiple tasks run needing to acquire the git lock file (add, commit, etc..).
By changing this value to 1, simple-git will now manage the queue of commands internally, running one at a time.


Before this change, i could upload 3 ~800kb jpgs and almost 100% of the time get a git error on 2 of the git add steps. This would eventually then lead to a git syncing error with the storage module.

Post this change, I could no longer reproduce the error.

There is likely a side effect of git actions take a bit longer on startup and if multiple page saves are happening simultaneously. Those tend to happen asynchronously in my observation so an end user likely wont see this slight slow down.