### PR TITLE
feat: add markdown-it-pivot-table rendering module

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "markdown-it-sub": "1.0.0",
     "markdown-it-sup": "1.0.0",
     "markdown-it-task-lists": "2.1.1",
+    "markdown-it-pivot-table": "1.0.0",
     "mathjax": "3.2.2",
     "mime-types": "2.1.35",
     "moment": "2.29.4",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "markdown-it-sub": "1.0.0",
     "markdown-it-sup": "1.0.0",
     "markdown-it-task-lists": "2.1.1",
-    "markdown-it-pivot-table": "1.0.0",
+    "markdown-it-pivot-table": "1.0.1",
     "mathjax": "3.2.2",
     "mime-types": "2.1.35",
     "moment": "2.29.4",

--- a/server/modules/rendering/markdown-pivot-table/definition.yml
+++ b/server/modules/rendering/markdown-pivot-table/definition.yml
@@ -1,0 +1,8 @@
+key: markdownPivotTable
+title: Pivot Table
+description: Add pivot table support
+author: jaeseopark
+icon: mdi-table
+enabledDefault: false
+dependsOn: markdownCore
+props: {}

--- a/server/modules/rendering/markdown-pivot-table/renderer.js
+++ b/server/modules/rendering/markdown-pivot-table/renderer.js
@@ -2,6 +2,6 @@ const pivotTable = require('markdown-it-pivot-table')
 
 module.exports = {
   init (md) {
-    md.use(pivotTable);
+    md.use(pivotTable)
   }
 }

--- a/server/modules/rendering/markdown-pivot-table/renderer.js
+++ b/server/modules/rendering/markdown-pivot-table/renderer.js
@@ -1,0 +1,7 @@
+const pivotTable = require('markdown-it-pivot-table')
+
+module.exports = {
+  init (md) {
+    md.use(pivotTable);
+  }
+}


### PR DESCRIPTION
Adding the [`markdown-it-pivot-table`](https://www.npmjs.com/package/markdown-it-pivot-table)  plugin to the list of rendering modules in wikijs.

It's my first time contributing. Please let me know what other things I need to do to get this PR merged.

### Screenshots

In Settings page:

<img width="952" alt="Screen Shot 2023-07-15 at 12 27 44 PM" src="https://github.com/requarks/wiki/assets/20038316/60d2083d-2998-4361-9b71-4cade32ebf18">
<img width="633" alt="Screen Shot 2023-07-15 at 12 28 22 PM" src="https://github.com/requarks/wiki/assets/20038316/dd637090-b64b-43e1-b3e6-30a25ed44b2f">

While Editing:

<img width="1008" alt="Screen Shot 2023-07-15 at 12 26 44 PM" src="https://github.com/requarks/wiki/assets/20038316/002f8bb1-474e-4f66-9d77-48823398564d">

Rendered Content:

<img width="991" alt="Screen Shot 2023-07-15 at 12 27 04 PM" src="https://github.com/requarks/wiki/assets/20038316/7f3ab84f-e9a6-4af2-bfe9-494b520595b2">
