### PR TITLE
introduced createFolderWithId and get all folders

### DIFF
--- a/server/graph/resolvers/asset.js
+++ b/server/graph/resolvers/asset.js
@@ -31,6 +31,13 @@ module.exports = {
         kind: a.kind.toUpperCase()
       }))
     },
+    async allFolders(obj, args, context) {
+      const results = await WIKI.models.assetFolders.query();
+      return results.filter(folder => {        
+        const path = folder.slug;
+        return WIKI.auth.checkAccess(context.req.user, ['read:assets'], { path });
+      });
+    },
     async folders(obj, args, context) {
       const results = await WIKI.models.assetFolders.query().where({
         parentId: args.parentFolderId === 0 ? null : args.parentFolderId
@@ -71,6 +78,37 @@ module.exports = {
         return graphHelper.generateError(err)
       }
     },
+    // new one
+    async createFolderWithId(obj, args, context) {
+        try {
+          const folderSlug = sanitize(args.slug).toLowerCase();
+          const parentFolderId = args.parentFolderId === 0 ? null : args.parentFolderId;
+          const result = await WIKI.models.assetFolders.query().where({
+            parentId: parentFolderId,
+            slug: folderSlug
+          }).first();
+          if (!result) {
+            const newFolder = await WIKI.models.assetFolders.query().insert({
+              slug: folderSlug,
+              name: folderSlug,
+              parentId: parentFolderId
+            });
+  
+            return {
+              folderId: newFolder.id,
+              parentId: newFolder.parentId,
+              response: graphHelper.generateSuccess('Asset Folder has been created successfully.')
+            };
+          } else {
+            throw new WIKI.Error.AssetFolderExists();
+          }
+        } catch (err) {
+          return {
+            folderId: null,
+            response: graphHelper.generateError(err)
+          };
+        }
+      },
     /**
      * Rename an Asset
      */

--- a/server/graph/schemas/asset.graphql
+++ b/server/graph/schemas/asset.graphql
@@ -23,6 +23,8 @@ type AssetQuery {
   folders(
     parentFolderId: Int!
   ): [AssetFolder] @auth(requires: ["manage:system", "read:assets"])
+
+  allFolders: [AssetFolder] @auth(requires: ["manage:system", "read:assets"])
 }
 
 # -----------------------------------------------
@@ -30,11 +32,19 @@ type AssetQuery {
 # -----------------------------------------------
 
 type AssetMutation {
-  createFolder(
+createFolder(
     parentFolderId: Int!
     slug: String!
     name: String
   ): DefaultResponse @auth(requires: ["manage:system", "write:assets"])
+
+  createFolderWithId(
+    parentFolderId: Int!
+    slug: String!
+    name: String
+  ): FolderCreationResponse @auth(requires: ["manage:system", "write:assets"])   
+  
+  # DefaultResponse @auth(requires: ["manage:system", "write:assets"])
 
   renameAsset(
     id: Int!
@@ -70,10 +80,17 @@ type AssetFolder {
   id: Int!
   slug: String!
   name: String
+  parentId: Int
 }
 
 enum AssetKind {
   IMAGE
   BINARY
   ALL
+}
+
+type FolderCreationResponse {  
+  folderId: Int
+  response: DefaultResponse
+  parentId: Int
 }


### PR DESCRIPTION
To support migration tool developments (from confluence, etc), I had to extend grapqhl schema and resolvers locally to allow getting all asstes folders in one query (instead of executing 1000s to build up folder structure) and also added a new create that returns newly created asset folder ID to avoid having additional query to look up after create.
Even tough grapqh is made for UI mainly, I belive these new queries can be helpful for ther teams.