### PR TITLE
fix: missing css style 'display: block;' for markdown code block in comments module

### DIFF
--- a/client/components/comments.vue
+++ b/client/components/comments.vue
@@ -547,6 +547,7 @@ export default {
       font-weight: 400;
       font-size: .85rem;
       font-family: Roboto Mono, monospace;
+      display: block;
     }
   }
 }


### PR DESCRIPTION
Add css style 'display: block;' for markdown code block in comments module, to ensure that the code block can be displayed properly.