### PR TITLE
fix: build Docker dev containers

### DIFF
--- a/dev/containers/Dockerfile
+++ b/dev/containers/Dockerfile
@@ -5,7 +5,7 @@ FROM node:18
 LABEL maintainer "requarks.io"
 
 RUN apt-get update && \
-    apt-get install -y bash curl git python make g++ nano openssh-server gnupg && \
+    apt-get install -y bash curl git python3-pip make g++ nano openssh-server gnupg && \
     mkdir -p /wiki
 
 WORKDIR /wiki


### PR DESCRIPTION
Hi, 
This PR is to fix the Docker dev container build. 

I got the following issues while building:

```bash
 => ERROR [wiki 2/3] RUN apt-get update &&     apt-get install -y bash curl git python make g++ nano openssh-server gnupg &&     mkd  5.7s
------
 > [wiki 2/3] RUN apt-get update &&     apt-get install -y bash curl git python make g++ nano openssh-server gnupg &&     mkdir -p /wiki:
[...]
#0 4.439 Package python is not available, but is referred to by another package.
#0 4.439 This may mean that the package is missing, has been obsoleted, or
#0 4.439 is only available from another source
#0 4.439 However the following packages replace it:
#0 4.439   python-is-python3 2to3
#0 4.439 
#0 4.457 E: Package 'python' has no installation candidate
```

I tested to build the container, install the dependancies (`yarn install`), and then a `yarn dev`. This seems OK now. 

Thanks,