### PR TITLE
feat: Adding Elestio with other deployment options

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,3 +500,6 @@ This project exists thanks to all the people who contribute. [[Contribute]](http
 
 ![Porkbun](https://static.requarks.io/logo/porkbun.png)  
 [Porkbun](https://www.porkbun.com) for providing domain registration services.
+
+[![Deploy](https://pub-da36157c854648669813f3f76c526c2b.r2.dev/deploy-on-elestio-black.png)](https://elest.io/open-source/wikijs)<br/>
+[Elestio](https://elest.io/) for providing their fully managed service along with security, backups, migrations and support to the project over revenue share.


### PR DESCRIPTION
Hey team,
I am Kaiwalya, Developer Advocate at Elestio. Elestio has been providing options of fully deploying and managing WikiJs application as shown [here](https://elest.io/open-source/wikijs). I think it would be a great idea if we can add it to official readme/documentation here.
In addition to this, if you are interested we provide partnership opportunities with tools we support by revenue share upon addition of this method in docs. If you would like to collaborate, just shoot me an email at kaiwalya@elest.io :)