### PR TITLE
Use rejectUnauthorized: conf.verifyTLSCertificate if no TLS is activated

### DIFF
--- a/server/modules/authentication/ldap/authentication.js
+++ b/server/modules/authentication/ldap/authentication.js
@@ -75,11 +75,7 @@ module.exports = {
 }
 
 function getTlsOptions(conf) {
-  if (!conf.tlsEnabled) {
-    return {}
-  }
-
-  if (!conf.tlsCertPath) {
+  if (!conf.tlsEnabled || !conf.tlsCertPath) {
     return {
       rejectUnauthorized: conf.verifyTLSCertificate
     }


### PR DESCRIPTION
Use rejectUnauthorized: conf.verifyTLSCertificate if no TLS is activated since ldaps still uses this flag.

