### PR TITLE
feat: update comment module "Artalk"

### DIFF
--- a/server/modules/comments/artalk/code.yml
+++ b/server/modules/comments/artalk/code.yml
@@ -6,7 +6,7 @@ head: |
 body: |
   <script>
     window.onload = function() {
-      new Artalk({
+      let artalk = Artalk.init({
         el:        '#artalk-container',
         pageKey:   '{{pageId}}',
         pageTitle: '',


### PR DESCRIPTION
The Artalk comment module is not compatible with Artalk v2.7+, which requires invocation on an instance created by either `Artalk.init` or `new Artalk`.

The updated `code.yml` works for both v2.7+ and older versions (tested with v2.6.4)
