### PR TITLE
fix: update Material Design Icon Library link

### DIFF
--- a/client/components/admin/admin-navigation.vue
+++ b/client/components/admin/admin-navigation.vue
@@ -156,7 +156,7 @@
                           )
                           .caption.pt-3.pl-5 The default icon set is #[strong Material Design Icons]. In order to use another icon set, you must first select it in the Theme administration section.
                           .caption.pt-3.pl-5: strong Material Design Icons
-                          .caption.pl-5 Refer to the #[a(href='https://materialdesignicons.com/', target='_blank') Material Design Icons Reference] for the list of all possible values. You must prefix all values with #[code mdi-], e.g. #[code mdi-home]
+                          .caption.pl-5 Refer to the #[a(href='https://pictogrammers.com/library/mdi/', target='_blank') Material Design Icon Library] for the list of all possible values. You must prefix all values with #[code mdi-], e.g. #[code mdi-home]
                           .caption.pt-3.pl-5: strong Font Awesome 5
                           .caption.pl-5 Refer to the #[a(href='https://fontawesome.com/icons?d=gallery&m=free', target='_blank') Font Awesome 5 Reference] for the list of all possible values. You must prefix all values with #[code fas fa-], e.g. #[code fas fa-home]. Note that some icons use different prefixes (e.g. #[code fab], #[code fad], #[code fal], #[code far]).
                           .caption.pt-3.pl-5: strong Font Awesome 4


### PR DESCRIPTION
In the admin panel's navigation settings, there is a link to the Material Design Icon Library. This PR updates the link to the new website. The [old link](https://materialdesignicons.com/) still works, but it shows an annoying popup telling you to "update your bookmarks" when it is clicked. Changing the link to the [new website](https://pictogrammers.com/library/mdi/) solves this.