### PR TITLE
refactor(templates): replace `polyfill.io`

### DIFF
--- a/dev/templates/legacy.pug
+++ b/dev/templates/legacy.pug
@@ -52,7 +52,7 @@ html
 
     script(
       crossorigin='anonymous'
-      src='https://polyfill.io/v3/polyfill.min.js?features=EventSource'
+      src='https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=EventSource'
     )
 
     //- JS


### PR DESCRIPTION
Wiki.js templates uses `polyfill.io` to polyfill `EventSource`. The PR replaces domain `polyfill.io` with `cdnjs.cloudflare.com/polyfill`.

---

`polyfill.io` was acquired by **a China-based CDN company** "Funnull", see [the announcement from the `polyfill.io` domain owner's Twitter](https://x.com/JakeDChampion/status/1761315227008643367) and https://github.com/polyfillpolyfill/polyfill-service/issues/2834. Despite Funnull's claims of operating in the United States, the predominance of Simplified Chinese on its website suggests otherwise, and it turns out that **"Funnull" is notorious for providing service for the betting and pornography industries**.

[The original creator of the `polyfill.io` has voiced his concern on Twitter](https://twitter.com/triblondon/status/1761852117579427975). And since the acquisition, numerous issues have emerged (https://github.com/polyfillpolyfill/polyfill-service/issues/2835, https://github.com/polyfillpolyfill/polyfill-service/issues/2838, https://github.com/alist-org/alist/issues/6100), rendering the `polyfill.io` service **extremely unstable**. Since then, Fastly ([Announcement](https://community.fastly.com/t/new-options-for-polyfill-io-users/2540)) and Cloudflare ([Announcement](https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk)) has hosted their own instances of `polyfill.io` service.