### PR TITLE
helm: render external database URL if it is set

### DIFF
--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             {{- end }}
             - name: DB_TYPE
               value: postgres
-            {{- if (.Values.externalPostgresql).databaseURL }}
+            {{- if and .Values.externalPostgresql .Values.externalPostgresql.databaseURL }}
             - name: DATABASE_URL
               value: {{ .Values.externalPostgresql.databaseURL }}
             - name: NODE_TLS_REJECT_UNAUTHORIZED


### PR DESCRIPTION
Before this PR, setting `externalPostgresql.databaseURL` did not cause the branch to be taken and `DATABASE_URL` to be rendered instead of the rest of env vars.

The exact reason why the syntax with parenthesis does not work eludes me.