### PR TITLE
Add support for azure ad b2c auth

### DIFF
--- a/server/modules/authentication/azure/authentication.js
+++ b/server/modules/authentication/azure/authentication.js
@@ -37,12 +37,16 @@ module.exports = {
         useCookieInsteadOfSession: keyArray.length > 0,
         cookieEncryptionKeys: keyArray
       }, async (req, iss, sub, profile, cb) => {
-        const usrEmail = _.get(profile, '_json.email', null) || _.get(profile, '_json.preferred_username')
+        const emails = _.get(profile, '_json.emails', null);
+        const id = _.get(profile, '_json.sub', null);
+
+        const usrEmail = _.get(profile, '_json.email', null) || _.get(profile, '_json.preferred_username') || emails[0]
+
         try {
           const user = await WIKI.models.users.processProfile({
             providerKey: req.params.strategy,
             profile: {
-              id: profile.oid,
+              id: profile.oid || id,
               displayName: profile.displayName,
               email: usrEmail,
               picture: ''


### PR DESCRIPTION
I was having problems trying to implement azure ad b2c user flow in Azure AD auth strategy. I kept getting the error "Invalid email / username or password on sign in".

After running some tests I found out that the issue came from the JWT sent by AZURE AD B2C auth which do not contain `email` or `preferred_username` claims expected by Azure AD authentication. The JWT from b2c returns the user email on an array claim `emails`.

I fix this by changing the following lines in `/server/modules/authentication/azure/authentication.js` file.

I changed:

```
const usrEmail = _.get(profile, '_json.email', null) || _.get(profile, '_json.preferred_username')
```

To:

```
const emails = _.get(profile, '_json.emails', null)
const usrEmail = _.get(profile, '_json.email', null) || _.get(profile, '_json.preferred_username') || emails[0]
```

Also, the JWT from B2C doesn't contain the `oid` claim. So I also change this lines to fix it:

From: 

```
profile: {
              id: profile.oid,
              displayName: profile.displayName,
              email: usrEmail,
              picture: ''
            }
```

To: 

```
const id = _.get(profile, '_json.sub', null)
profile: {
              id: profile.oid || id,
              displayName: profile.displayName,
              email: usrEmail,
              picture: ''
            }
```

I tested everything and it worked as expected.

@NGPixel I'd like to get your feedback as soon as possible. Thank you!