### PR TITLE
fix: page pagination in tags component

### DIFF
--- a/client/components/tags.vue
+++ b/client/components/tags.vue
@@ -98,6 +98,7 @@
           :search='innerSearch'
           :loading='isLoading'
           :options.sync='pagination'
+          @page-count='pageTotal = $event'
           hide-default-footer
           ref='dude'
           )
@@ -183,6 +184,7 @@ export default {
         sortDesc: [false]
       },
       pages: [],
+      pageTotal: 0,
       isLoading: true,
       scrollStyle: {
         vuescroll: {},
@@ -213,9 +215,6 @@ export default {
     },
     tagsSelected () {
       return _.filter(this.tags, t => _.includes(this.selection, t.tag))
-    },
-    pageTotal () {
-      return Math.ceil(this.pages.length / this.pagination.itemsPerPage)
     },
     orderByItems () {
       return [


### PR DESCRIPTION
The same as https://github.com/requarks/wiki/pull/4280 that resolved https://github.com/requarks/wiki/issues/1180,  but now in the tags component. 

The pagination number was always static based on all pages within the selected tags, now it also reflects the search.