### PR TITLE
Added option for embedding plantuml diagram as an object tag

### DIFF
--- a/server/modules/rendering/markdown-plantuml/definition.yml
+++ b/server/modules/rendering/markdown-plantuml/definition.yml
@@ -39,3 +39,10 @@ props:
       - ascii
     order: 4
     public: true
+  renderSvgAsObject:
+    type: Boolean
+    default: false
+    title: Render svg as object tag instead of img tag
+    hint: Allows for interactive content like links in plantuml graphs - it may have security implications
+    order: 5
+    public: true

--- a/server/modules/rendering/markdown-plantuml/renderer.js
+++ b/server/modules/rendering/markdown-plantuml/renderer.js
@@ -13,6 +13,7 @@ module.exports = {
       const closeChar = closeMarker.charCodeAt(0)
       const imageFormat = opts.imageFormat || 'svg'
       const server = opts.server || 'https://plantuml.requarks.io'
+      const renderSvgAsObject = opts.renderSvgAsObject || false
 
       md.block.ruler.before('fence', 'uml_diagram', (state, startLine, endLine, silent) => {
         let nextLine
@@ -114,16 +115,27 @@ module.exports = {
 
         const zippedCode = encode64(zlib.deflateRawSync('@startuml\n' + contents + '\n@enduml').toString('binary'))
 
-        token = state.push('uml_diagram', 'img', 0)
-        // alt is constructed from children. No point in populating it here.
-        token.attrs = [ [ 'src', `${server}/${imageFormat}/${zippedCode}` ], [ 'alt', '' ], ['class', 'uml-diagram prefetch-candidate'] ]
-        token.block = true
-        token.children = altToken
-        token.info = params
-        token.map = [ startLine, nextLine ]
-        token.markup = markup
-
-        state.line = nextLine + (autoClosed ? 1 : 0)
+        if (renderSvgAsObject && imageFormat === 'svg') {
+          token = state.push('uml_diagram', 'object', 0)
+          // alt is constructed from children. No point in populating it here.
+          token.attrs = [['data', `${server}/${imageFormat}/${zippedCode}`], ['alt', ''], ['type', 'image/svg+xml'], ['class', 'uml-diagram prefetch-candidate']]
+          token.block = true
+          token.children = []
+          token.info = params
+          token.map = [startLine, nextLine]
+          token.markup = markup
+          state.line = nextLine + (autoClosed ? 1 : 0)
+        } else {
+          token = state.push('uml_diagram', 'img', 0)
+          // alt is constructed from children. No point in populating it here.
+          token.attrs = [['src', `${server}/${imageFormat}/${zippedCode}`], ['alt', ''], ['class', 'uml-diagram prefetch-candidate']]
+          token.block = true
+          token.children = altToken
+          token.info = params
+          token.map = [startLine, nextLine]
+          token.markup = markup
+          state.line = nextLine + (autoClosed ? 1 : 0)
+        }
 
         return true
       }, {
@@ -134,7 +146,8 @@ module.exports = {
       openMarker: conf.openMarker,
       closeMarker: conf.closeMarker,
       imageFormat: conf.imageFormat,
-      server: conf.server
+      server: conf.server,
+      renderSvgAsObject: conf.renderSvgAsObject
     })
   }
 }


### PR DESCRIPTION
Follow up of: https://github.com/requarks/wiki/pull/2754 and https://github.com/requarks/wiki/discussions/3597

Summary:
Added option to allow plantuml diagrams in svg format to be rendered as <object> tags.

This PR does the following:
- Adds renderSvgAsObject option
- Adds branches in editor and server renderer

Tests:
✅ Links in plantuml work in rendered page when option is enabled, also with enabled Security Plugin.
❌ Links in plantuml don't work in editing mode - seem to be sanitised?. Also configuration options are not available in editor renderer.

Tested Using simple markdown:
``````
# Header

```plantuml
:[[http://example.com TEST]];

```
``````
