### PR TITLE
Enabled plantuml interactive

### DIFF
--- a/client/components/editor/markdown/plantuml.js
+++ b/client/components/editor/markdown/plantuml.js
@@ -13,6 +13,7 @@ module.exports = {
       const closeChar = closeMarker.charCodeAt(0)
       const imageFormat = opts.imageFormat || 'svg'
       const server = opts.server || 'https://plantuml.requarks.io'
+      const renderSvgAsObject = opts.renderSvgAsObject || false
 
       md.block.ruler.before('fence', 'uml_diagram', (state, startLine, endLine, silent) => {
         let nextLine
@@ -134,7 +135,8 @@ module.exports = {
       openMarker: conf.openMarker,
       closeMarker: conf.closeMarker,
       imageFormat: conf.imageFormat,
-      server: conf.server
+      server: conf.server,
+      renderSvgAsObject: conf.renderSvgAsObject
     })
   }
 }

--- a/server/modules/rendering/markdown-plantuml/definition.yml
+++ b/server/modules/rendering/markdown-plantuml/definition.yml
@@ -39,3 +39,10 @@ props:
       - ascii
     order: 4
     public: true
+  renderSvgAsObject:
+    type: Boolean
+    default: false
+    title: Render svg as object tag instead of img tag
+    hint: Allows for interactive content like links in plantuml graphs - it may have security implications
+    order: 5
+    public: true

--- a/server/modules/rendering/markdown-plantuml/renderer.js
+++ b/server/modules/rendering/markdown-plantuml/renderer.js
@@ -13,6 +13,7 @@ module.exports = {
       const closeChar = closeMarker.charCodeAt(0)
       const imageFormat = opts.imageFormat || 'svg'
       const server = opts.server || 'https://plantuml.requarks.io'
+      const renderSvgAsObject = opts.renderSvgAsObject || false
 
       md.block.ruler.before('fence', 'uml_diagram', (state, startLine, endLine, silent) => {
         let nextLine
@@ -129,12 +130,22 @@ module.exports = {
       }, {
         alt: [ 'paragraph', 'reference', 'blockquote', 'list' ]
       })
-      md.renderer.rules.uml_diagram = md.renderer.rules.image
+      if (renderSvgAsObject && imageFormat === 'svg') {
+        md.renderer.rules.uml_diagram = (tokens, idx) => {
+          const currentToken = tokens[idx]
+          const src = currentToken.attrGet('src')
+          const clazz = currentToken.attrGet('class')
+          return `<object data='${src}' class="${clazz}"></object>`
+        }
+      } else {
+        md.renderer.rules.uml_diagram = md.renderer.rules.image
+      }
     }, {
       openMarker: conf.openMarker,
       closeMarker: conf.closeMarker,
       imageFormat: conf.imageFormat,
-      server: conf.server
+      server: conf.server,
+      renderSvgAsObject: conf.renderSvgAsObject
     })
   }
 }


### PR DESCRIPTION
Summary:
Adds ability for interactive links in plantuml and other interactive content from generated svg.

What is included:
- renderSvgAsObject switch in plantuml admin tab - to disable and enable this functionality
- New token parser implementation for markdown-it instead of reusing image parser, because lack of '</object>' tag breaks the rest of the page.
- Added variables to frontend editor to signal possibility of implementation of this functionality in editor 

Dogfooding & Testing:
Using on hackerspace page: https://docs.hsp.sh/en/public/zarz%C4%85d/procesy/payments
Testing on this image: ghcr.io/hspsh/wiki.js/wiki:v2.5.303-plantuml-2
