### PR TITLE
helm: add pod annotations

### DIFF
--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         {{- include "wiki.selectorLabels" . | nindent 8 }}
+      annotations:
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -42,6 +42,8 @@ startupProbe:
     path: /healthz
     port: http
 
+podAnnotations: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
Before, there was no way to add pod annotations via the helm chart.