### PR TITLE
feat: add initContainers to deployment

### DIFF
--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -24,8 +24,9 @@ spec:
       serviceAccountName: {{ include "wiki.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.sideload.enabled }}
+      {{- if or .Values.sideload.enabled .Values.initContainers }}
       initContainers:
+        {{- if or .Values.sideload.enabled }}
         - name: {{ .Chart.Name }}-sideload
           securityContext:
             {{- toYaml .Values.sideload.securityContext | nindent 12 }}
@@ -37,6 +38,10 @@ spec:
           args: [ "mkdir -p /wiki/data/sideload && git clone --depth=1 {{ .Values.sideload.repoURL }} /wiki/data/sideload/" ]
           resources:
             {{- toYaml .Values.sideload.resources | nindent 12 }}
+        {{- end }}
+        {{- with .Values.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
For one of our customer's environments, we need to execute additional commands in the container's operating system via an initContainer. Therefore, we would need the possibility to pass such an init container to the WikiJS Helm chart.