### PR TITLE
Allow `HA_ACTIVE: True` to enable HA mode

### DIFF
--- a/server/core/db.js
+++ b/server/core/db.js
@@ -222,8 +222,7 @@ module.exports = {
    * Subscribe to database LISTEN / NOTIFY for multi-instances events
    */
   async subscribeToNotifications () {
-    const useHA = (WIKI.config.ha === true || WIKI.config.ha === 'true' || WIKI.config.ha === 'True' || WIKI.config.ha === 'TRUE' ||
-                   WIKI.config.ha === 1 || WIKI.config.ha === '1')
+    const useHA = (WIKI.config.ha === true || (typeof WIKI.config.ha === 'string' && WIKI.config.ha.toLowerCase() === 'true') || WIKI.config.ha === 1 || WIKI.config.ha === '1')
     if (!useHA) {
       return
     } else if (WIKI.config.db.type !== 'postgres') {

--- a/server/core/db.js
+++ b/server/core/db.js
@@ -222,7 +222,8 @@ module.exports = {
    * Subscribe to database LISTEN / NOTIFY for multi-instances events
    */
   async subscribeToNotifications () {
-    const useHA = (WIKI.config.ha === true || WIKI.config.ha === 'true' || WIKI.config.ha === 1 || WIKI.config.ha === '1')
+    const useHA = (WIKI.config.ha === true || WIKI.config.ha === 'true' || WIKI.config.ha === 'True' || WIKI.config.ha === 'TRUE' ||
+                   WIKI.config.ha === 1 || WIKI.config.ha === '1')
     if (!useHA) {
       return
     } else if (WIKI.config.db.type !== 'postgres') {


### PR DESCRIPTION
When something python-like (carvel ytt, ansible etc.) is used in deploying wiki - it is highly likely to have a construction similar to:
```yaml
      env:
        - name: HA_ACTIVE
          value: #@ str(data.values.replicas > 1)
```
which produces `"True"` in config and counter-intuitively does _not_ enable high-availability mode, leading to corresponding issues with caching (page edits not reflected until a lot of refreshes, randomly returning stale pages and so on - because not all workers actually refresh the page cache)

With this simple edit we can significantly decrease user frustration