### PR TITLE
Add ability to set additional labels for pods

### DIFF
--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
     metadata:
       labels:
         {{- include "wiki.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       annotations:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
     spec:

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -44,6 +44,8 @@ startupProbe:
 
 podAnnotations: {}
 
+podLabels: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 


### PR DESCRIPTION
Adds the option to add labels to pods created by the helm chart. This is useful for setting network policies, etc.