### PR TITLE
fix: Verify folderId when uploading files on server side

### DIFF
--- a/server/controllers/upload.js
+++ b/server/controllers/upload.js
@@ -49,6 +49,9 @@ router.post('/u', (req, res, next) => {
     const folderRaw = _.get(req, 'body.mediaUpload', false)
     if (folderRaw) {
       folderId = _.get(JSON.parse(folderRaw), 'folderId', null)
+      if (typeof folderId !== 'number') {
+        throw new Error('Invalid folderId')
+      }
       if (folderId === 0) {
         folderId = null
       }

--- a/server/controllers/upload.js
+++ b/server/controllers/upload.js
@@ -49,7 +49,7 @@ router.post('/u', (req, res, next) => {
     const folderRaw = _.get(req, 'body.mediaUpload', false)
     if (folderRaw) {
       folderId = _.get(JSON.parse(folderRaw), 'folderId', null)
-      if (typeof folderId !== 'number') {
+      if (!Number.isInteger(folderId)) {
         throw new Error('Invalid folderId')
       }
       if (folderId === 0) {


### PR DESCRIPTION
Add a type check for folderId when uploading files to ensure it is a number.

