### PR TITLE
feat: allow author of page with write:pages permission to delete the page they created

### DIFF
--- a/client/themes/default/components/page.vue
+++ b/client/themes/default/components/page.vue
@@ -559,11 +559,14 @@ export default {
     tocDecoded () {
       return JSON.parse(Buffer.from(this.toc, 'base64').toString())
     },
+    currentUserId: get('user/id'),
     tocPosition: get('site/tocPosition'),
     hasAdminPermission: get('page/effectivePermissions@system.manage'),
     hasWritePagesPermission: get('page/effectivePermissions@pages.write'),
     hasManagePagesPermission: get('page/effectivePermissions@pages.manage'),
-    hasDeletePagesPermission: get('page/effectivePermissions@pages.delete'),
+    hasDeletePagesPermission() {
+      return get('page/effectivePermissions@pages.delete').call(this) || (this.authorId === this.currentUserId && this.hasWritePagesPermission)
+    },
     hasReadSourcePermission: get('page/effectivePermissions@source.read'),
     hasReadHistoryPermission: get('page/effectivePermissions@history.read'),
     hasAnyPagePermissions () {

--- a/server/graph/schemas/page.graphql
+++ b/server/graph/schemas/page.graphql
@@ -130,7 +130,7 @@ type PageMutation {
 
   delete(
     id: Int!
-  ): DefaultResponse @auth(requires: ["delete:pages", "manage:system"])
+  ): DefaultResponse @auth(requires: ["delete:pages", "write:pages", "manage:system"])
 
   deleteTag(
     id: Int!

--- a/server/models/pages.js
+++ b/server/models/pages.js
@@ -795,10 +795,17 @@ module.exports = class Page extends Model {
     }
 
     // -> Check for page access
-    if (!WIKI.auth.checkAccess(opts.user, ['delete:pages'], {
+    const isTheAuthorAndHasWritePermission = page.authorId === opts.user.id && WIKI.auth.checkAccess(opts.user, ['write:pages'], {
       locale: page.locale,
       path: page.path
-    })) {
+    })
+
+    const hasDeletePermission = WIKI.auth.checkAccess(opts.user, ['delete:pages'], {
+      locale: page.locale,
+      path: page.path
+    })
+
+    if (!isTheAuthorAndHasWritePermission && !hasDeletePermission) {
       throw new WIKI.Error.PageDeleteForbidden()
     }
 


### PR DESCRIPTION
This PR enhances the page deletion logic to support ownership-based access control in addition to role-based permissions.

- Allows users to delete a page if they are the original author and have write:pages permission for that page's locale/path.
- Users with explicit delete:pages permission for the page still retain full deletion rights.

## Why

This change supports a more intuitive and flexible permission model:

- Empowers content authors to manage (delete) their own work without requiring broader delete permissions.