### PR TITLE
feat: Set groups based on Entra groups (Azure auth module)

### DIFF
--- a/server/modules/authentication/azure/authentication.js
+++ b/server/modules/authentication/azure/authentication.js
@@ -48,6 +48,19 @@ module.exports = {
               picture: ''
             }
           })
+          if (conf.mapGroups) {
+            const groups = _.get(profile, '_json.groups')
+            if (groups && _.isArray(groups)) {
+              const currentGroups = (await user.$relatedQuery('groups').select('groups.id')).map(g => g.id)
+              const expectedGroups = Object.values(WIKI.auth.groups).filter(g => groups.includes(g.name)).map(g => g.id)
+              for (const groupId of _.difference(expectedGroups, currentGroups)) {
+                await user.$relatedQuery('groups').relate(groupId)
+              }
+              for (const groupId of _.difference(currentGroups, expectedGroups)) {
+                await user.$relatedQuery('groups').unrelate().where('groupId', groupId)
+              }
+            }
+          }
           cb(null, user)
         } catch (err) {
           cb(err, null)

--- a/server/modules/authentication/azure/definition.yml
+++ b/server/modules/authentication/azure/definition.yml
@@ -27,3 +27,9 @@ props:
     title: Cookie Encryption Key String
     hint: Random string with 44-character length.  Setting this enables workaround for Chrome's SameSite cookies.
     order: 3
+  mapGroups:
+    type: Boolean
+    title: Map Groups
+    hint: Map groups matching names from the groups claim value
+    default: false
+    order: 4


### PR DESCRIPTION
# Add group synchronization for Entra ID (aka. Azure AD)

Azure AD is now called Entra, hence the name of the auth module.

This is a copy-paste of the code used from generic OAuth2, except the group claim name is always "groups". This is not configurable in Entra, so no configuration is needed here either. It solves #1874 for the Azure module, as others have already done for SAML and OIDC.

# User how-to

1. Enable the "groups" claim in Entra under App Registrations ("Token configuration" -> "Add groups claim").
2. Edit the Azure auth module in Wiki.js, and enable the new setting ("Map groups").
3. Create the groups in Wiki.js.
4. Groups are mapped during the auth process, so users have to log in again.