### PR TITLE
Log error and message when authentication fails

### DIFF
--- a/server/models/users.js
+++ b/server/models/users.js
@@ -312,8 +312,14 @@ module.exports = class User extends Model {
           session: !strInfo.useForm,
           scope: strInfo.scopes ? strInfo.scopes : null
         }, async (err, user, info) => {
-          if (err) { return reject(err) }
-          if (!user) { return reject(new WIKI.Error.AuthLoginFailed()) }
+          if (err) {
+            WIKI.logger.warn(`Error trying to authenticate with strategy ${selStrategy.key}: ${JSON.stringify({ err, info })}`)
+            return reject(err)
+          }
+          if (!user) {
+            WIKI.logger.info(`Authentication failed with strategy ${selStrategy.key}: ${JSON.stringify(info)}`)
+            return reject(new WIKI.Error.AuthLoginFailed())
+          }
 
           try {
             const resp = await WIKI.models.users.afterLoginChecks(user, context, {


### PR DESCRIPTION
This can help to identify any integration problems when using authentication strategy (e.g. Generic OpenID Connect / OAuth2).

Currently there is no info if there is some problem. UI just says "Invalid user or password" and there is nothing in logs.

Adding this simple log helped me to identify that I have improper issuer URL and that there is some problem with certificate chain, example messages:
```
Error trying to authenticate with strategy <key>: {"err":{"name":"InternalOAuthError","message":"Failed to obtain access token","oauthError":{"code":"UNABLE_TO_VERIFY_LEAF_SIGNATURE"}}}
```
```
Authentication failed with strategy <key>: {"err":null,"info":{"message":"ID token not issued by expected OpenID provider."}}
```