### PR TITLE
Switch service port on the exposed container port

### DIFF
--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -57,7 +57,7 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 80
+  port: 3000
   # Annotations applied for services such as externalDNS or
   # service type LoadBalancer
   # type: LoadBalancer


### PR DESCRIPTION
Hi, 

Just a little pull request for the helm chart. 
Switching the service to match with the container exposed port. 

