### PR TITLE
feat(chart): add custom environment variables to the deployment

### DIFF
--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -81,6 +81,9 @@ spec:
             {{- end }}
             - name: HA_ACTIVE
               value: {{ .Values.replicaCount | int | le 2 | quote }}
+            {{- with .Values.extraEnvVars }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
     {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- toYaml . | nindent 12 }}

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -138,6 +138,17 @@ sideload:
 ## Append extra trusted certificates for node process from extra volume via NODE_EXTRA_CA_CERTS variable
 # nodeExtraCaCerts: "/path/to/certs.pem"
 
+## Additional environment variables to set
+extraEnvVars: []
+# extraEnvVars:
+#   - name: CUSTOM_VAR
+#     value: "custom_value"
+#   - name: SECRET_VAR
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: secret-key
+
 ## This will override the postgresql chart values
 # externalPostgresql:
 #   # note: ?sslmode=require => ?ssl=true


### PR DESCRIPTION
Hi, first of all thanks for creating and maintaining both wikijs and it's helm chart.

For our deployment we need to use the `PGSSLMODE:   require` environment variable in the deployment. Instead of adding that option I've found more potentially useful for other users to let thme define environment variables.

Thanks!