### PR TITLE
Add ability to customize helm values for deployment strategy

### DIFF
--- a/dev/helm/README.md
+++ b/dev/helm/README.md
@@ -99,6 +99,9 @@ The following table lists the configurable parameters of the Wiki.js chart and t
 | `imagePullPolicy`                    | Image pull policy                           | `IfNotPresent`                                             |
 | `replicacount`                       | Number of Wiki.js pods to run                   | `1`                                                        |
 | `revisionHistoryLimit`               | Total number of revision history points                   | `10`                                        |
+| `strategy.type`               | Strategy used to replace old pods by new ones                   | `RollingUpdate`                                        |
+| `strategy.rollingUpdate.maxSurge`               | Maximum number of pods that can be created over the desired replica count during the upgrade process                   | `25%`                                        |
+| `strategy.rollingUpdate.maxUnavailable`               | Maximum number of pods that can be unavailable during the upgrade process                   | `25%`                                        |
 | `resources.limits`               | Wiki.js service resource limits                         | `nil`                               |
 | `resources.requests`             | Wiki.js service resource requests                       | `nil`                               |
 | `nodeSelector`                   | Node labels for the Wiki.js pod assignment          | `{}`                                                       |

--- a/dev/helm/templates/deployment.yaml
+++ b/dev/helm/templates/deployment.yaml
@@ -7,6 +7,13 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  strategy:
+    type: {{ .Values.strategy.type }}
+    {{- if eq .Values.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.strategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   selector:
     matchLabels:
       {{- include "wiki.selectorLabels" . | nindent 6 }}

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -5,6 +5,12 @@
 replicaCount: 1
 revisionHistoryLimit: 10
 
+strategy:
+  type: "RollingUpdate"
+  rollingUpdate:
+    maxSurge: "25%"
+    maxUnavailable: "25%"
+
 image:
   repository: requarks/wiki
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
### Changes

- Adds ability to customize deployment rollout `strategy.type` in the wiki helm chart ("RollingUpdate" vs. "Recreate")
- With `strategy.type="RollingUpdate"`, `maxSurge` and `maxUnavailable` are also customizable via helm values
- Documentation updated with descriptions/defaults for new helm values

###  Testing
Default behavior is unchanged (`RollingUpdate - 25% - 25%`)
```
$ helm template . | grep -A4 strategy
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
```
Rendering with `strategy.type` set to `Recreate`
```
$ helm template --set strategy.type="Recreate" . | grep -A4 strategy
  strategy:
    type: Recreate
  selector:
    matchLabels:
      app.kubernetes.io/name: wiki
```
Customizing `maxSurge`
```
$ helm template --set strategy.rollingUpdate.maxSurge="100%" . | grep -A4 strategy
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxSurge: 100%
      maxUnavailable: 25%
```
Customizing `maxUnavailable`
```
$ helm template --set strategy.rollingUpdate.maxUnavailable="100%" . | grep -A4 strategy
  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 100%
```