### PR TITLE
fix: multiple vega branch bug fixes for auth, pages, mail

### DIFF
--- a/server/controllers/auth.mjs
+++ b/server/controllers/auth.mjs
@@ -42,10 +42,11 @@ export default function () {
   router.get('/login/:strategy', async (req, res, next) => {
     try {
       await WIKI.db.users.login({
-        strategy: req.params.strategy
+        strategyId: req.params.strategy
       }, { req, res })
     } catch (err) {
-      next(err)
+      WIKI.logger.error(`OAuth login error: ${err.message}`)
+      res.redirect('/login?error=' + encodeURIComponent(err.message))
     }
   })
 
@@ -57,7 +58,7 @@ export default function () {
 
     try {
       const authResult = await WIKI.db.users.login({
-        strategy: req.params.strategy
+        strategyId: req.params.strategy
       }, { req, res })
       res.cookie('jwt', authResult.jwt, { expires: DateTime.now().plus({ years: 1 }).toJSDate() })
 
@@ -74,7 +75,8 @@ export default function () {
         res.redirect('/')
       }
     } catch (err) {
-      next(err)
+      WIKI.logger.error(`OAuth callback error: ${err.message}`)
+      res.redirect('/login?error=' + encodeURIComponent(err.message))
     }
   })
 

--- a/server/core/mail.mjs
+++ b/server/core/mail.mjs
@@ -68,9 +68,11 @@ export default {
   },
   async loadTemplate(key, opts = {}) {
     try {
-      return this.vueEmail.render(`${key}.vue`, {
+      const result = await this.vueEmail.render(`${key}.vue`, {
         props: opts
       })
+      // vue-email render returns { html, text } - extract html string
+      return typeof result === 'object' ? result.html : result
     } catch (err) {
       WIKI.logger.warn(err)
       throw new Error('ERR_MAIL_RENDER_FAILED')

--- a/server/models/pages.mjs
+++ b/server/models/pages.mjs
@@ -430,7 +430,7 @@ export class Page extends Model {
 
     // -> Basic fields
     if ('title' in opts.patch) {
-      patch.title = opts.patch.title.trim()
+      patch.title = (opts.patch.title ?? '').trim()
       historyData.affectedFields.push('title')
       shouldUpdateSearch = true
 
@@ -440,18 +440,18 @@ export class Page extends Model {
     }
 
     if ('description' in opts.patch) {
-      patch.description = opts.patch.description.trim()
+      patch.description = (opts.patch.description ?? '').trim()
       historyData.affectedFields.push('description')
       shouldUpdateSearch = true
     }
 
     if ('icon' in opts.patch) {
-      patch.icon = opts.patch.icon.trim()
+      patch.icon = (opts.patch.icon ?? '').trim()
       historyData.affectedFields.push('icon')
     }
 
     if ('alias' in opts.patch) {
-      patch.alias = opts.patch.alias.trim()
+      patch.alias = (opts.patch.alias ?? '').trim()
       historyData.affectedFields.push('alias')
 
       if (patch.alias.length > 255) {

--- a/server/models/users.mjs
+++ b/server/models/users.mjs
@@ -191,7 +191,7 @@ export class User extends Model {
     // Update existing user
     if (user) {
       if (!user.isActive) {
-        throw new WIKI.Error.AuthAccountBanned()
+        throw new Error('ERR_ACCOUNT_BANNED')
       }
       if (user.isSystem) {
         throw new Error('This is a system reserved account and cannot be used.')
@@ -216,7 +216,7 @@ export class User extends Model {
       if (get(provider, 'domainWhitelist', []).length > 0) {
         const emailDomain = last(primaryEmail.split('@'))
         if (!provider.domainWhitelist.includes(emailDomain)) {
-          throw new WIKI.Error.AuthRegistrationDomainUnauthorized()
+          throw new Error('ERR_AUTH_REGISTRATION_DOMAIN_UNAUTHORIZED')
         }
       }
 
@@ -257,7 +257,7 @@ export class User extends Model {
     if (has(WIKI.auth.strategies, strategyId)) {
       const selStrategy = WIKI.auth.strategies[strategyId]
       if (!selStrategy.isEnabled) {
-        throw new WIKI.Error.AuthProviderInvalid()
+        throw new Error('ERR_AUTH_PROVIDER_INVALID')
       }
 
       const strInfo = find(WIKI.data.authentication, ['key', selStrategy.module])
@@ -276,7 +276,10 @@ export class User extends Model {
           scope: strInfo.scopes ? strInfo.scopes : null
         }, async (err, user, info) => {
           if (err) { return reject(err) }
-          if (!user) { return reject(new WIKI.Error.AuthLoginFailed()) }
+          if (!user) {
+            WIKI.logger.error('Auth failed - no user returned. Info: ' + JSON.stringify(info))
+            return reject(new Error('ERR_LOGIN_FAILED'))
+          }
 
           try {
             const resp = await WIKI.db.users.afterLoginChecks(user, selStrategy.id, context, {
@@ -291,7 +294,7 @@ export class User extends Model {
         })(context.req, context.res, () => {})
       })
     } else {
-      throw new WIKI.Error.AuthProviderInvalid()
+      throw new Error('ERR_AUTH_PROVIDER_INVALID')
     }
   }
 
@@ -411,7 +414,7 @@ export class User extends Model {
       }
       if (!user.isActive) {
         WIKI.logger.warn(`Failed to refresh token for user ${user}: Inactive.`)
-        throw new WIKI.Error.AuthAccountBanned()
+        throw new Error('ERR_ACCOUNT_BANNED')
       }
     } else if (isNil(user.groups)) {
       user.groups = await user.$relatedQuery('groups').select('groups.id', 'permissions')
@@ -829,7 +832,7 @@ export class User extends Model {
     if (context.req.user.strategyId && has(WIKI.auth.strategies, context.req.user.strategyId)) {
       const selStrategy = WIKI.auth.strategies[context.req.user.strategyId]
       if (!selStrategy.isEnabled) {
-        throw new WIKI.Error.AuthProviderInvalid()
+        throw new Error('ERR_AUTH_PROVIDER_INVALID')
       }
       const provider = find(WIKI.data.authentication, ['key', selStrategy.module])
       if (provider.logout) {


### PR DESCRIPTION
## Summary

Bug fixes found while deploying Wiki.js 3.0 (vega branch) in production on AWS EKS with Node.js 24.

**No UI changes, no customizations - server-side fixes only.**

## Fixes

### 1. Auth Controller - strategyId field name (`server/controllers/auth.mjs`)
`/login/:strategy` and `/login/:strategy/callback` routes pass `{ strategy: req.params.strategy }` to `users.login()`, but the method destructures `{ strategyId }`. This causes all OAuth/OIDC logins to fail with `AuthProviderInvalid`.

### 2. Auth Controller - Error handling (`server/controllers/auth.mjs`)
OAuth callback errors cause `Internal Server Error` (500) because `next(err)` tries to render an error template but no view engine is configured in the vega branch. Changed to redirect to `/login?error=message`.

### 3. WIKI.Error undefined (`server/models/users.mjs`)
`WIKI.Error.AuthLoginFailed()`, `WIKI.Error.AuthProviderInvalid()`, `WIKI.Error.AuthAccountBanned()` all crash with `Cannot read properties of undefined (reading 'AuthLoginFailed')` because `WIKI.Error` is not initialized. Replaced with standard `new Error()` calls.

### 4. Null-safe .trim() (`server/models/pages.mjs`)
`updatePage` crashes with `Cannot read properties of null (reading 'trim')` when `title`, `description`, `icon`, or `alias` is null in the update patch. Added `?? ''` before `.trim()`.

### 5. Mail template rendering (`server/core/mail.mjs`)
`@vue-email/compiler` `render()` returns `{ html: string, text: string }` but `loadTemplate()` returns the object directly to nodemailer's `html` field, causing `The "chunk" argument must be of type string`. Now extracts `result.html`.

## Test Environment
- AWS EKS (Kubernetes 1.29)
- Node.js 24
- PostgreSQL 16.8 (Aurora)
- OIDC with self-hosted GitLab