### PR TITLE
fix: Display file upload limits in UI

### DIFF
--- a/client/components/editor/editor-modal-media.vue
+++ b/client/components/editor/editor-modal-media.vue
@@ -142,7 +142,7 @@
                 :label-idle='$t(`editor:assets.uploadAssetsDropZone`)'
                 allow-multiple='true'
                 :files='files'
-                max-files='10'
+                :max-files='uploadLimits.maxFiles'
                 :server='filePondServerOpts'
                 :instant-upload='false'
                 :allow-revert='false'
@@ -150,7 +150,7 @@
               )
             v-divider
             v-card-actions.pa-3
-              .caption.grey--text.text-darken-2 Max 10 files, 5 MB each
+              .caption.grey--text.text-darken-2 Max {{ uploadLimits.maxFiles }} files, {{ uploadLimits.maxFileSize | prettyBytes }} each
               v-spacer
               v-btn.px-4(color='teal', dark, @click='upload') {{$t('common:actions.upload')}}
 
@@ -291,6 +291,12 @@ export default {
     folderTree: get('editor/media@folderTree'),
     currentFolderId: sync('editor/media@currentFolderId'),
     currentFileId: sync('editor/media@currentFileId'),
+    uploadLimits() {
+      return {
+        maxFiles: this.$store.state.site.uploadMaxFiles,
+        maxFileSize: this.$store.state.site.uploadMaxFileSize
+      }
+    },
     pageTotal () {
       if (!this.assets) {
         return 0

--- a/client/store/site.js
+++ b/client/store/site.js
@@ -11,6 +11,8 @@ const state = {
   mascot: true,
   title: siteConfig.title,
   logoUrl: siteConfig.logoUrl,
+  uploadMaxFileSize: siteConfig.uploadMaxFileSize,
+  uploadMaxFiles: siteConfig.uploadMaxFiles,
   search: '',
   searchIsFocused: false,
   searchIsLoading: false,

--- a/server/master.js
+++ b/server/master.js
@@ -155,7 +155,9 @@ module.exports = async () => {
       company: WIKI.config.company,
       contentLicense: WIKI.config.contentLicense,
       footerOverride: WIKI.config.footerOverride,
-      logoUrl: WIKI.config.logoUrl
+      logoUrl: WIKI.config.logoUrl,
+      uploadMaxFileSize: WIKI.config.uploads.maxFileSize,
+      uploadMaxFiles: WIKI.config.uploads.maxFiles
     }
     res.locals.langs = await WIKI.models.locales.getNavLocales({ cache: true })
     res.locals.analyticsCode = await WIKI.models.analytics.getCode({ cache: true })


### PR DESCRIPTION
This PR updates the UI of the Media Editor to actually display the correct values for max file size and max files.

Fixes https://github.com/requarks/wiki/discussions/6440

<img width="647" height="377" alt="Bildschirmfoto_20260423_161650" src="https://github.com/user-attachments/assets/6d7cd15d-3a6d-4a62-961a-e5997850a2a1" />