### PR TITLE
fix: null-guard storage targets and page tags to prevent crashes

### DIFF
--- a/server/models/storage.js
+++ b/server/models/storage.js
@@ -179,7 +179,7 @@ module.exports = class Storage extends Model {
 
   static async pageEvent({ event, page }) {
     try {
-      for (let target of this.targets) {
+      for (let target of (this.targets || [])) {
         await target.fn[event](page)
       }
     } catch (err) {
@@ -190,7 +190,7 @@ module.exports = class Storage extends Model {
 
   static async assetEvent({ event, asset }) {
     try {
-      for (let target of this.targets) {
+      for (let target of (this.targets || [])) {
         await target.fn[`asset${_.capitalize(event)}`](asset)
       }
     } catch (err) {
@@ -201,7 +201,7 @@ module.exports = class Storage extends Model {
 
   static async getLocalLocations({ asset }) {
     const locations = []
-    const promises = this.targets.map(async (target) => {
+    const promises = (this.targets || []).map(async (target) => {
       try {
         const path = await target.fn.getLocalLocation(asset)
         locations.push({

--- a/server/modules/storage/disk/common.js
+++ b/server/modules/storage/disk/common.js
@@ -87,7 +87,7 @@ module.exports = {
         id: currentPage.id,
         title: _.get(pageData, 'title', currentPage.title),
         description: _.get(pageData, 'description', currentPage.description) || '',
-        tags: newTags || currentPage.tags.map(t => t.tag),
+        tags: newTags || (currentPage.tags || []).map(t => t.tag),
         isPublished: _.get(pageData, 'isPublished', currentPage.isPublished),
         isPrivate: false,
         content: pageData.content,


### PR DESCRIPTION
 ## Problem

Two places in the storage layer can throw a `TypeError: Cannot read properties of undefined` when iterating over collections that may not be initialized:

  - `Storage.targets` can be `undefined` when storage hasn't been
    activated/configured yet. Affects `pageEvent`, `assetEvent`, and
    `getLocalLocations`.
  - `currentPage.tags` can be `undefined` when a page was imported or
    created without tags. Affects the disk storage `common.js` handler.

## Fix

Add `|| []` fallback guards so these methods degrade gracefully instead of throwing:

  - `server/models/storage.js` — 3 occurrences
  - `server/modules/storage/disk/common.js` — 1 occurrence