### PR TITLE
fix: include full stack traces in error logs

### DIFF
--- a/server/core/logger.js
+++ b/server/core/logger.js
@@ -7,6 +7,7 @@ module.exports = {
   loggers: {},
   init(uid) {
     const loggerFormats = [
+      winston.format.errors({ stack: true }),
       winston.format.label({ label: uid }),
       winston.format.timestamp()
     ]
@@ -15,7 +16,7 @@ module.exports = {
       loggerFormats.push(winston.format.json())
     } else {
       loggerFormats.push(winston.format.colorize())
-      loggerFormats.push(winston.format.printf(info => `${info.timestamp} [${info.label}] ${info.level}: ${info.message}`))
+      loggerFormats.push(winston.format.printf(info => `${info.timestamp} [${info.label}] ${info.level}: ${info.message}${info.stack ? '\n' + info.stack : ''}`))
     }
 
     const logger = winston.createLogger({

--- a/server/jobs/fetch-graph-locale.js
+++ b/server/jobs/fetch-graph-locale.js
@@ -61,6 +61,6 @@ module.exports = async (localeCode) => {
     WIKI.logger.info(`Fetching locale ${localeCode} from Graph endpoint: [ COMPLETED ]`)
   } catch (err) {
     WIKI.logger.error(`Fetching locale ${localeCode} from Graph endpoint: [ FAILED ]`)
-    WIKI.logger.error(err.message)
+    WIKI.logger.error(err)
   }
 }

--- a/server/jobs/purge-uploads.js
+++ b/server/jobs/purge-uploads.js
@@ -27,6 +27,6 @@ module.exports = async () => {
     WIKI.logger.info('Purging orphaned upload files: [ COMPLETED ]')
   } catch (err) {
     WIKI.logger.error('Purging orphaned upload files: [ FAILED ]')
-    WIKI.logger.error(err.message)
+    WIKI.logger.error(err)
   }
 }

--- a/server/jobs/rebuild-tree.js
+++ b/server/jobs/rebuild-tree.js
@@ -73,7 +73,7 @@ module.exports = async (pageId) => {
     WIKI.logger.info(`Rebuilding page tree: [ COMPLETED ]`)
   } catch (err) {
     WIKI.logger.error(`Rebuilding page tree: [ FAILED ]`)
-    WIKI.logger.error(err.message)
+    WIKI.logger.error(err)
     // exit process with error code
     throw err
   }

--- a/server/jobs/render-page.js
+++ b/server/jobs/render-page.js
@@ -89,7 +89,7 @@ module.exports = async (pageId) => {
     WIKI.logger.info(`Rendering page ID ${pageId}: [ COMPLETED ]`)
   } catch (err) {
     WIKI.logger.error(`Rendering page ID ${pageId}: [ FAILED ]`)
-    WIKI.logger.error(err.message)
+    WIKI.logger.error(err)
     // exit process with error code
     throw err
   }

--- a/server/jobs/sanitize-svg.js
+++ b/server/jobs/sanitize-svg.js
@@ -19,7 +19,7 @@ module.exports = async (svgPath) => {
     WIKI.logger.info(`Sanitized SVG file upload: [ COMPLETED ]`)
   } catch (err) {
     WIKI.logger.error(`Failed to sanitize SVG file upload: [ FAILED ]`)
-    WIKI.logger.error(err.message)
+    WIKI.logger.error(err)
     throw err
   }
 }


### PR DESCRIPTION
  ## Problem

Error logs across all job handlers only logged `err.message`, which drops the stack trace entirely. This makes it very hard to diagnose where errors originate.

## Fix

  - `server/core/logger.js`: add `winston.format.errors({ stack: true })`
    to the format chain, and update the printf format to append the stack
    when present.
  - `server/jobs/*.js` (8 files): pass the full `err` object to
    `WIKI.logger.error()` instead of `err.message`.