### PR TITLE
Make rendered markdown task list checkboxes clickable

### DIFF
--- a/client/components/editor/editor-markdown.vue
+++ b/client/components/editor/editor-markdown.vue
@@ -267,7 +267,7 @@ const md = new MarkdownIt({
   .use(mdDecorate)
   .use(underline)
   .use(mdEmoji)
-  .use(mdTaskLists, { label: false, labelAfter: false })
+  .use(mdTaskLists, { enabled: true, label: false, labelAfter: false })
   .use(mdExpandTabs)
   .use(mdAbbr)
   .use(mdSup)

--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -790,12 +790,13 @@
     position: relative;
     list-style-type: none;
 
-    &-checkbox[disabled] {
+    &-checkbox {
       width: 1.1rem;
       height: 1.1rem;
       top: 2px;
       position: relative;
       margin-right: 2px;
+      cursor: pointer;
 
       &::after {
         position: absolute;
@@ -819,7 +820,8 @@
         }
       }
 
-      &[checked]::after  {
+      &[checked]::after,
+      &:checked::after {
         content: '✓';
       }
     }

--- a/server/modules/rendering/markdown-tasklists/renderer.js
+++ b/server/modules/rendering/markdown-tasklists/renderer.js
@@ -6,6 +6,6 @@ const mdTaskLists = require('markdown-it-task-lists')
 
 module.exports = {
   init (md, conf) {
-    md.use(mdTaskLists, { label: false, labelAfter: false })
+    md.use(mdTaskLists, { enabled: true, label: false, labelAfter: false })
   }
 }

--- a/server/test/modules/rendering/markdown-tasklists.test.js
+++ b/server/test/modules/rendering/markdown-tasklists.test.js
@@ -1,0 +1,17 @@
+const MarkdownIt = require('markdown-it')
+const taskListsRenderer = require('../../../../server/modules/rendering/markdown-tasklists/renderer')
+
+describe('rendering/markdown-tasklists', () => {
+  it('renders interactive task list checkboxes', () => {
+    const md = new MarkdownIt()
+
+    taskListsRenderer.init(md, {})
+
+    const result = md.render('- [ ] unchecked\n- [x] checked')
+
+    expect(result).toContain('class="task-list-item enabled"')
+    expect(result).toContain('class="task-list-item-checkbox"')
+    expect(result).toContain('checked=""')
+    expect(result).not.toContain('disabled="disabled"')
+  })
+})


### PR DESCRIPTION
## Summary
Implements the feature request to allow rendered Markdown task list checkboxes to be clicked without entering edit mode. (https://js.wiki/feedback/p/allow-checkboxes-to-be-checked-without-editing)

Checkbox toggles are visual-only and are not persisted back to the Markdown source. This is useful for temporary checklist workflows, such as filling out a template before printing.

## Changes
- enable interactive task list checkboxes in the server Markdown renderer
- enable the same behavior in the Markdown editor preview
- update task list checkbox styling so it no longer depends on `disabled`
- add a focused renderer test to verify `disabled` is not emitted

## Verification
1. Create or edit a Markdown page with:
   - [ ] unchecked task
   - [x] checked task
2. Save the page
3. View the rendered page
4. Click the checkboxes and confirm they can be toggled visually

## Test
```bash
npx jest server/test/modules/rendering/markdown-tasklists.test.js
```

## Screenshot
Rendered Markdown task list checkboxes are now clickable without entering edit mode.
<img width="943" height="528" alt="checkbox" src="https://github.com/user-attachments/assets/4d41a1f2-2206-4817-97b3-c5ca54034dcf" />