### PR TITLE
Made title clickable. Improves ux on desktop and mobile

### DIFF
--- a/client/components/common/nav-header.vue
+++ b/client/components/common/nav-header.vue
@@ -43,7 +43,7 @@
           //-       v-list-item-content
           //-         v-list-item-title.body-2.grey--text.text--ligten-2 {{$t('common:header.imagesFiles')}}
           //-         v-list-item-subtitle.overline.grey--text.text--lighten-2 Coming soon
-          v-toolbar-title(:class='{ "mx-3": $vuetify.breakpoint.mdAndUp, "mx-1": $vuetify.breakpoint.smAndDown }')
+          v-toolbar-title(:class='{ "mx-3": $vuetify.breakpoint.mdAndUp, "mx-1": $vuetify.breakpoint.smAndDown }', @click='goHome')
             span.subheading {{title}}
       v-flex(md4, v-if='$vuetify.breakpoint.mdAndUp')
         v-toolbar.nav-header-inner(color='black', dark, flat)
@@ -501,6 +501,10 @@ export default {
       padding: 0 14px 0 5px;
       padding-right: 14px;
     }
+  }
+
+  .v-toolbar__title{
+    cursor: pointer;
   }
 
   .org-logo {


### PR DESCRIPTION
It frustrated me a bit that you couldn't click on the title like you could with a lot of other sites. I quickly added a link and css tag like with clicking the icon. Hope you can add this to the next release.