### PR TITLE
fix: apply RTL direction class in the page editor

### DIFF
--- a/client/components/editor.vue
+++ b/client/components/editor.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-  v-app.editor(:dark='$vuetify.theme.dark')
+  v-app.editor(:dark='$vuetify.theme.dark', :class='$vuetify.rtl ? `is-rtl` : `is-ltr`')
     nav-header(dense)
       template(slot='mid')
         v-text-field.editor-title-input(

--- a/client/themes/default/scss/app.scss
+++ b/client/themes/default/scss/app.scss
@@ -663,7 +663,7 @@
     }
   }
 
-  ul:not(.tabset-tabs):not(.contains-task-list) {
+  ul:not(.tabset-tabs):not(.contains-task-list):not(.todo-list) {
     list-style: none;
     > li::before {
       position: absolute;


### PR DESCRIPTION
TL;DR: Hebrew (RTL) text in the visual editor didn't play well with bullet lists/todo lists.

The reader view (themes/default/components/page.vue) sets `is-rtl`/`is-ltr` on the root `v-app` from `$vuetify.rtl`, so all `.is-rtl` content styles apply to rendered pages. The editor's root `v-app` (components/editor.vue) was missing this class, so for RTL the CKEditor "Visual" editor rendered content left-to-right, so list bullets stayed on the left. I copied the reader's binding so the editor inherits the same `.is-rtl` content rules.

<img width="1711" height="225" alt="Screenshot_2026-06-17_17-27-52" src="https://github.com/user-attachments/assets/46974a4f-d65f-43e8-a9e2-886958e260a2" />

The content list-bullet rule (themes/default/scss/app.scss) draws a custom `::before` bullet on `ul` and excludes `.contains-task-list` (markdown task lists, where the checkbox is the marker). The CKEditor "Visual" editor emits task lists with class `.todo-list`, which was not excluded, so the bullet rendered in the task-list checkbox - in both the editor and the saved/rendered output. Exclude `.todo-list` as well.

<img width="508" height="394" alt="image" src="https://github.com/user-attachments/assets/599a1c20-cb00-42c1-8cac-1fb2790fbb77" />

Result:
<img width="85" height="286" alt="image" src="https://github.com/user-attachments/assets/3eaaf01a-8cbd-463a-aca7-fe26d7b619bb" />
