### PR TITLE
chore: docker container config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Database
+POSTGRES_DB=wiki
+POSTGRES_USER=wikijs
+POSTGRES_PASSWORD=changeme
+
+# Connection (leave blank and commented for local, fill in for AWS RDS)
+#DB_HOST=
+#DB_PORT=
+#DB_SSL=false

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ test-results/
 
 # Localization Resources
 /server/locales/**/*.yml
+
+# Environment variables
+.env

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,0 +1,32 @@
+# Wiki.js Docker Setup
+
+## Local Development
+
+### Prerequisites
+- Docker Desktop installed and running
+
+### Steps
+1. Clone the repo
+2. Copy the env file: `copy .env.example .env`
+3. Fill in your values in `.env`
+4. Run: `docker compose up -d`
+5. Open: `http://localhost`
+
+## AWS ECS Deployment
+
+### Prerequisites
+- AWS CLI configured
+- ECR repository created
+- RDS PostgreSQL instance running
+
+### Steps
+1. Build the image: `docker build -t wikijs .`
+2. Push to ECR: follow AWS ECR push commands
+3. Update ECS Task Definition with your RDS env vars:
+   - DB_HOST=your-rds-endpoint.amazonaws.com
+   - DB_PORT=5432
+   - DB_USER=wikijs
+   - DB_PASS=yourpassword
+   - DB_NAME=wiki
+   - DB_SSL=true
+4. Deploy the ECS service

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/requarks/wiki:2
+
+EXPOSE 3000
+
+CMD ["node", "server"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+services:
+
+  db:
+    image: postgres:15-alpine
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    logging:
+      driver: none
+    restart: unless-stopped
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+  wiki:
+    image: ghcr.io/requarks/wiki:2
+    depends_on:
+      - db
+    init: true
+    environment:
+      DB_TYPE: postgres
+      DB_HOST: ${DB_HOST:-db}
+      DB_PORT: ${DB_PORT:-5432}
+      DB_USER: ${POSTGRES_USER}
+      DB_PASS: ${POSTGRES_PASSWORD}
+      DB_NAME: ${POSTGRES_DB}
+      DB_SSL: ${DB_SSL:-false}
+    restart: unless-stopped
+    ports:
+      - "80:3000"
+
+volumes:
+  db-data:


### PR DESCRIPTION
## Summary
This PR adds Docker configuration to run Wiki.js locally using Docker 
Compose and prepares it for AWS ECS deployment.

---

## Changes
- Added `docker-compose.yml` for local development
- Added `Dockerfile` as a base for future customization
- Added `.env.example` as a reference for required environment variables
- Added `CONFIG.md` with instructions for local and AWS ECS deployment

---

## How to Run Locally

### Prerequisites
- Docker Desktop installed and running

### Steps
1. Pull lates changes.
2. Copy the env file:
```bash
   copy .env.example .env
```
3. Fill in your values in `.env`
   > Note: Comment out `DB_HOST` and `DB_PORT` for local development
4. Start the containers:
```bash
   docker compose up -d
```
5. Open `http://localhost` in your browser
6. Complete the Wiki.js setup wizard

---

## Environment Variables

| Variable | Description | Required |
|---|---|---|
| `POSTGRES_DB` | Database name | ✅ |
| `POSTGRES_USER` | Database username | ✅ |
| `POSTGRES_PASSWORD` | Database password | ✅ |
| `DB_HOST` | RDS endpoint (AWS only) | AWS only |
| `DB_PORT` | Database port (AWS only) | AWS only |
| `DB_SSL` | Enable SSL (AWS only) | AWS only |

---

## Notes for AWS ECS Deployment
- `docker-compose.yml` is for **local development only**
- AWS ECS will use the **ECS Task Definition** instead
- Replace the PostgreSQL container with **AWS RDS** on deployment
- Set `DB_HOST`, `DB_PORT`, and `DB_SSL=true` in ECS environment variables
- Sensitive values should be stored in **AWS Secrets Manager**

---

## Tested
- ✅ Containers start successfully with `docker compose up -d`
- ✅ Wiki.js accessible at `http://localhost`
- ✅ PostgreSQL connection established successfully
- ✅ Wiki.js setup wizard loads correctly