### PR TITLE
Add Gateway API HTTPRoute support to the Wiki.js Helm chart

### DIFF
--- a/dev/helm/README.md
+++ b/dev/helm/README.md
@@ -112,6 +112,10 @@ The following table lists the configurable parameters of the Wiki.js chart and t
 | `ingress.annotations`                | Ingress annotations                         | `{}`                                                       |
 | `ingress.hosts`                      | List of ingress rules                        | `[{"host": "wiki.local", "paths": ["/"]}]`                |
 | `ingress.tls`                        | Ingress TLS configuration                   | `[]`                                                       |
+| `httpRoute.enabled`                  | Enable Gateway API HTTPRoute resource       | `false`                                                    |
+| `httpRoute.annotations`              | HTTPRoute annotations                       | `{}`                                                       |
+| `httpRoute.hostnames`                | Hostnames the route matches (empty = all)   | `[]`                                                       |
+| `httpRoute.parentRefs`               | Gateway(s) the route attaches to            | `[]`                                                       |
 | `sideload.enabled`                   | Enable sideloading of locale files from git | `false`                                                    |
 | `sideload.repoURL`                   | Git repository URL containing locale files  | `https://github.com/Requarks/wiki-localization`            |
 | `sideload.env`                       | Environment variables for the sideload container | `{}`                                                      |
@@ -211,6 +215,22 @@ See the [Configuration](#configuration) section to configure the PVC or to disab
 ## Ingress
 
 This chart provides support for Ingress resource. If you have an available Ingress Controller such as Nginx or Traefik you maybe want to set `ingress.enabled` to true and add `ingress.hosts` for the URL. Then, you should be able to access the installation using that address.
+
+## HTTPRoute (Gateway API)
+
+As an alternative to Ingress, the chart can expose Wiki.js through a [Gateway API](https://gateway-api.sigs.k8s.io/) `HTTPRoute`. Set `httpRoute.enabled` to true and provide at least one entry in `httpRoute.parentRefs` pointing to your `Gateway`:
+
+```yaml
+httpRoute:
+  enabled: true
+  parentRefs:
+    - name: my-gateway
+      namespace: gateway-system
+  hostnames:
+    - wiki.example.com
+```
+
+This requires the Gateway API CRDs and a Gateway controller to be installed in the cluster. The resource is disabled by default, so clusters without the Gateway API are unaffected.
 
 ## Extra Trusted Certificates
 

--- a/dev/helm/templates/httproute.yaml
+++ b/dev/helm/templates/httproute.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.httpRoute.enabled -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "wiki.fullname" . }}
+  labels:
+    {{- include "wiki.labels" . | nindent 4 }}
+  {{- with .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  parentRefs:
+    {{- toYaml .Values.httpRoute.parentRefs | nindent 4 }}
+  rules:
+    - backendRefs:
+        - kind: Service
+          name: {{ include "wiki.fullname" . }}
+          port: {{ .Values.service.port }}
+          weight: 1
+      matches:
+        - path:
+            type: PathPrefix
+            value: /
+{{- end -}}

--- a/dev/helm/values.yaml
+++ b/dev/helm/values.yaml
@@ -81,6 +81,24 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
+# Gateway API HTTPRoute. Enable as an alternative to ingress when using a
+# Gateway controller. Disabled by default to avoid requiring the Gateway API
+# CRDs on clusters that don't have them installed.
+httpRoute:
+  enabled: false
+  # Annotations to add to the HTTPRoute resource
+  annotations: {}
+  # Hostnames the route matches. Leave empty to match every hostname
+  # attached to the parent Gateway listener.
+  hostnames: []
+    # - wiki.minikube.local
+  # References to the Gateway(s) this route attaches to. At least one is
+  # required when httpRoute.enabled is true.
+  parentRefs: []
+    # - name: my-gateway
+    #   namespace: gateway-system
+    #   sectionName: http
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This adds an optional Gateway API HTTPRoute template to the Wiki.js Helm
chart, as an alternative to the existing Ingress for clusters that route
with a Gateway controller. It is disabled by default (httpRoute.enabled:
false), so clusters without the Gateway API CRDs are unaffected.

Changes:
- New templates/httproute.yaml, gated on httpRoute.enabled, backed by the
  existing Service (service.port).
- httpRoute block in values.yaml (enabled, annotations, hostnames,
  parentRefs) with inline comments.
- README: parameter table rows plus an "HTTPRoute (Gateway API)" section.

Validation (helm v3.18.1):
- helm lint --strict: pass
- httpRoute.enabled=false (default): nothing rendered
- httpRoute.enabled=true with parentRefs and hostnames: valid HTTPRoute
- enabled with hostnames omitted: hostnames field correctly dropped
- full chart render: no regressions