### PR TITLE
Stored XSS via Theming Configuration in Wiki.js

### DIFF
--- a/server/graph/resolvers/theming.js
+++ b/server/graph/resolvers/theming.js
@@ -47,8 +47,8 @@ module.exports = {
           darkMode: args.darkMode,
           tocPosition: args.tocPosition || 'left',
           injectCSS: args.injectCSS || '',
-          injectHead: args.injectHead || '',
-          injectBody: args.injectBody || ''
+          injectHead: args.injectHead ? args.injectHead.replace(/<script/gi, '') : '',
+          injectBody: args.injectBody ? args.injectBody.replace(/<script/gi, '') : ''
         }
 
         await WIKI.configSvc.saveToDb(['theming'])


### PR DESCRIPTION
A Stored Cross-Site Scripting (XSS) vulnerability exists in the theming configuration resolver of Wiki.js v2.5.314. The `injectHead` and `injectBody` fields accepted by the `ThemingMutation.setConfig` GraphQL mutation are stored without sanitization and rendered unsanitized into every wiki page via Pug's unescaped `!=` operator (`server/views/page.pug`). An authenticated administrator with `manage:theme` permission can supply a malicious JavaScript payload that executes in the browser of every user — authenticated or not — on every page load across the entire wiki instance.

**## Reproduction Steps**

1. Log in as an administrator.
2. Open the browser DevTools console or use a GraphQL client. Call the `theming.setConfig` mutation with the following payload:
   ```
   injectHead: "<script>alert('XSS-002: JWT='+document.cookie.substring(0,50));</script>"
   ```
3. Navigate to any wiki page (as admin or any other user).
4. Observe: an alert popup fires displaying the current user's JWT cookie value (e.g., `XSS-002: JWT=eyJ...`).
5. Confirm: the alert fires on **every wiki page** for **every user** — including unauthenticated visitors — until the payload is removed.

