### PR TITLE
Full-Read SSRF via HTML Image Prefetch Renderer in Wiki.js

### DIFF
--- a/server/modules/rendering/html-image-prefetch/renderer.js
+++ b/server/modules/rendering/html-image-prefetch/renderer.js
@@ -1,7 +1,22 @@
 const request = require('request-promise')
+const { URL } = require('url')
+
+const BLOCKED_HOSTS = /^(127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|169\.254\.|::1$|::ffff:)/
+
+function isSafeUrl (urlStr) {
+  let parsed
+  try { parsed = new URL(urlStr) } catch { return false }
+  if (!['http:', 'https:'].includes(parsed.protocol)) return false
+  if (parsed.hostname === 'localhost' || BLOCKED_HOSTS.test(parsed.hostname)) return false
+  return true
+}
 
 const prefetch = async (element) => {
   const url = element.attr(`src`)
+  if (!isSafeUrl(url)) {
+    WIKI.logger.warn(`Blocked unsafe prefetch URL: ${url}`)
+    return
+  }
   let response
   try {
     response = await request({


### PR DESCRIPTION
**## Description**

Wiki.js v2.5.314 contains a Full-Read Server-Side Request Forgery (SSRF) vulnerability in the `html-image-prefetch` rendering module (`server/modules/rendering/html-image-prefetch/renderer.js`). When this renderer is enabled by an administrator, any `<img>` element with `class="prefetch-candidate"` in a page's HTML content causes the wiki server to make a server-side GET request to the element's `src` URL using `request-promise` — with no URL validation, no private IP blocking, and no allowlist. The **complete HTTP response body** is base64-encoded and embedded as a `data:` URI in the rendered page HTML, making the full response contents visible to any page viewer. This is the first full-read SSRF finding in Wiki.js history.

**Pre-condition:** The `html-image-prefetch` renderer must be enabled by an administrator (Administration → Rendering → HTML Image Prefetch → ON). It is disabled by default (`enabledDefault: false`). Once enabled, any editor-level user can exploit this without further admin interaction.


**## Reproduction Steps**

1. As an administrator, enable the HTML Image Prefetch renderer: Administration → Rendering → HTML Image Prefetch → ON.
2. Start a simple HTTP server on a port that is accessible server-side but **not** externally (e.g., `127.0.0.1:19876`) serving a file `/secrets.txt` with sensitive content. Verify from an external browser that `http://<wiki-host>:19876/secrets.txt` returns connection refused.
3. Log in as an attacker account (`attacker@test.local`) with only `write:pages` permission.
4. Create a new page using the Code (HTML) editor with the following content:
   ```html
   <img class="prefetch-candidate" src="http://127.0.0.1:19876/secrets.txt" alt="ssrf-probe">
   ```
5. Save and view the rendered page.
6. Right-click → View Page Source. Locate the `<img>` tag and observe the `src` attribute has been replaced with a `data:text/plain;base64,...` URI.
7. Decode the base64 value. Observe: the full contents of `/secrets.txt` are returned — a resource that was unreachable from the external browser.

