### PR TITLE
Add scope field and examples to OIDC authentication configuration

### DIFF
--- a/server/modules/authentication/oidc/authentication.js
+++ b/server/modules/authentication/oidc/authentication.js
@@ -22,6 +22,7 @@ module.exports = {
         passReqToCallback: true,
         skipUserProfile: conf.skipUserProfile,
         acrValues: conf.acrValues
+        scope: conf.scope
       }, async (req, iss, uiProfile, idProfile, context, idToken, accessToken, refreshToken, params, cb) => {
         const profile = Object.assign({}, idProfile, uiProfile)
         const picture = _.get(profile, '_json.' + conf.pictureClaim, '')

--- a/server/modules/authentication/oidc/definition.yml
+++ b/server/modules/authentication/oidc/definition.yml
@@ -92,3 +92,8 @@ props:
     title: ACR Values
     hint: (optional) Authentication Context Class Reference
     order: 14
+  scope:
+    type: String
+    title: Scope
+    hint: (optional) Additional permission scopes to request. 'openid profile email' are always included.
+    order: 15

--- a/server/modules/authentication/oidc/definition.yml
+++ b/server/modules/authentication/oidc/definition.yml
@@ -95,5 +95,5 @@ props:
   scope:
     type: String
     title: Scope
-    hint: (optional) Additional permission scopes to request. 'openid profile email' are always included.
+    hint: (optional) Additional permission scopes to request. 'openid profile email' are always included. Add extra scopes here, e.g. 'roles'.
     order: 15


### PR DESCRIPTION
## Problem

The Generic OpenID Connect / OAuth2 strategy currently hardcodes the requested scopes (openid profile email). Users who need additional scopes — e.g. group/role scopes like roles for group mapping — have no way to request them. The IdP only releases claims (such as group memberships or, in some setups, even the email claim) when the corresponding scope is present in the authorization request, so group mapping silently fails regardless of the "Map Groups" setting.

## Change

- Add an optional scope field to the strategy configuration (definition.yml)

- Pass the configured value through to the OIDC strategy (authentication.js), so it is included in the authorization request

- The default scopes openid profile email remain always included; the new field only adds scopes

## Behavior

- Fully backward compatible: leaving the field empty behaves exactly like before

- Example: setting openid profile email roles requests a roles scope, which the IdP can then release as a group claim for Map Groups