### PR TITLE
fix: reload auth strategies when site URL changes

### DIFF
--- a/server/graph/resolvers/site.js
+++ b/server/graph/resolvers/site.js
@@ -41,6 +41,7 @@ module.exports = {
   SiteMutation: {
     async updateConfig(obj, args, context) {
       try {
+        const previousHost = WIKI.config.host
         if (args.hasOwnProperty('host')) {
           let siteHost = _.trim(args.host)
           if (siteHost.endsWith('/')) {
@@ -131,6 +132,11 @@ module.exports = {
           WIKI.app.enable('trust proxy')
         } else {
           WIKI.app.disable('trust proxy')
+        }
+
+        if (WIKI.config.host !== previousHost) {
+          await WIKI.auth.activateStrategies()
+          WIKI.events.outbound.emit('reloadAuthStrategies')
         }
 
         return {


### PR DESCRIPTION
Hello,

When you change the Site URL under Administration > General, the new host is saved and the providers pages even shows the new callback URLs.
The `redirect_uri` actually sent to OIDC/OAuth providers stays on the old FQDN though.

Auth strategies bake that callback from the Site URL when they load. Changing host doesn't reload them, so you have to restart Wiki.js for login to pick up the new URL. Updating the host should just rebuild those callbacks IMO.

Thomas