### PR TITLE
Tree Navbar: Show children instead of siblings for folder

### DIFF
--- a/client/themes/default/components/nav-sidebar.vue
+++ b/client/themes/default/components/nav-sidebar.vue
@@ -211,10 +211,16 @@ export default {
       }
 
       this.parents = [this.currentParent, ...invertedAncestors.reverse()]
+
+      if (curPage.isFolder) {
+        // Show children for folder, instead of siblings
+        this.parents.push(curPage)
+      }
+
       this.currentParent = _.last(this.parents)
 
-      this.loadedCache = [curPage.parent]
-      this.currentItems = _.filter(items, ['parent', curPage.parent])
+      this.loadedCache = [this.currentParent.pageId || 0]
+      this.currentItems = _.filter(items, ['parent', this.currentParent.pageId || 0])
       this.$store.commit(`loadingStop`, 'browse-load')
     },
     goHome () {

--- a/server/graph/resolvers/page.js
+++ b/server/graph/resolvers/page.js
@@ -252,14 +252,19 @@ module.exports = {
       if (!args.locale) { args.locale = WIKI.config.lang.code }
 
       if (args.path && !args.parent) {
-        curPage = await WIKI.models.knex('pageTree').first('parent', 'ancestors').where({
+        curPage = await WIKI.models.knex('pageTree').first('parent', 'ancestors', 'pageId', 'isFolder').where({
           path: args.path,
           localeCode: args.locale
         })
-        if (curPage) {
-          args.parent = curPage.parent || 0
-        } else {
+        if (!curPage) {
           return []
+        }
+        if (curPage.isFolder) {
+          // Get children
+          args.parent = curPage.pageId || 0
+        } else {
+          // Get siblings
+          args.parent = curPage.parent || 0
         }
       }
 
@@ -277,6 +282,10 @@ module.exports = {
           builder.whereNull('parent')
         } else {
           builder.where('parent', args.parent)
+          if (curPage && curPage.isFolder) {
+            // When getting children, we also need to include curPage itself
+            builder.orWhere('id', curPage.pageId)
+          }
           if (args.includeAncestors && curPage && curPage.ancestors.length > 0) {
             builder.orWhereIn('id', _.isString(curPage.ancestors) ? JSON.parse(curPage.ancestors) : curPage.ancestors)
           }


### PR DESCRIPTION
We are currently adopting wikijs as a new wiki at our organization, and I quite like it. However, there is one thing that is really unintuitive and has confused me, as well as other people:

When you go to a page that is a folder (i.e. has children), the tree sidebar shows the folder and all it's siblings. I would expect it to show the children of the folder/page you are on.
This is especially confusing when navigating in the tree to a page. When you click on the page and it loads, the sidebar automatically "goes back up" one level in the hierarchy. I would expect the sidebar to stay the same after clicking/showing any page. Note: There is an old PR #2933 where people have mentioned the same problem.

This PR fixes that by showing the children instead of siblings for pages which have children. Pages which have no children behave exactly the same. Only two small changes are necessary:

- On the server, the `tree` graphql query is changed a bit for queries with a `path`: For pages which are a folder, the children are queried instead of the siblings. Queries to `tree` with a `parent` behave as before. This should not impact anything else, as the navbar is the only place I could find where a `tree` query with `path` is made.
- On the client, we push the current page to the list of parents if the page is a folder

I have tested this locally and it works really well.

I know that this changes previous behaviour a bit, but I think this way it is much more intuitive. I would really appreciate if this could be merged!